### PR TITLE
changed shabang -> #!/usr/bin/env python2.7

### DIFF
--- a/scripts/sphinxtrain
+++ b/scripts/sphinxtrain
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2.7
 
 import getopt, sys, os
 


### PR DESCRIPTION
When python3 is installed it will be the default python executable thus breaking the sphinxtrain executable caused by unparameterized print statements.