### PR TITLE
Output an error message when we cannot execute a tool

### DIFF
--- a/scripts/lib/SphinxTrain/Util.pm
+++ b/scripts/lib/SphinxTrain/Util.pm
@@ -343,7 +343,7 @@ sub RunTool {
 
   if ($pid == 0) {
       open STDERR, ">&STDOUT";
-      exec $cmd, @args;
+      exec $cmd, @args or print STDERR "ERROR: Cannot exec '$cmd': $!\n";
   }
   else {
     while (<$pipe>) {

--- a/src/programs/bw/backward.c
+++ b/src/programs/bw/backward.c
@@ -418,7 +418,7 @@ backward_update(float64 **active_alpha,
 	 q_f < n_active_astate[n_obs-1] &&
 	     active_astate[n_obs-1][q_f] != (n_state-1); q_f++);
     if (q_f == n_active_astate[n_obs-1]) {
-	E_ERROR("Failed to align audio to trancript: final state of the search is not reached\n");
+	E_ERROR("Failed to align audio to transcript: final state of the search is not reached\n");
 	return S3_ERROR;
     }
 


### PR DESCRIPTION
This change adds an error message in the perl script when we have problem executing a tool.

I don't have pocketsphinx installed, so when I run sphinxtrain, it gives me an odd error message saying the match file is not found. While that's true, it is hard for me to understand what's gone wrong. Turn out we used to just ignore the error of not being able to run pocketsphinx, so we don't have the match files.

With the change, the HTML file will indicate clearly cannot run pocketsphinx, hopefully that can save others time debugging this.
