### PR TITLE
Add includes and fix number of params for bio call

### DIFF
--- a/include/s3/corpus.h
+++ b/include/s3/corpus.h
@@ -58,6 +58,7 @@ extern "C" {
 #include <s3/vector.h>
 #include <s3/acmod_set.h>
 #include <s3/s3phseg_io.h>
+#include <s3/s3io.h>
 
 #include <stdio.h>
 #include <stddef.h>

--- a/include/s3/lexicon.h
+++ b/include/s3/lexicon.h
@@ -57,6 +57,7 @@ extern "C" {
 #include <s3/acmod_set.h>
 #include <sphinxbase/prim_type.h>
 #include <sphinxbase/hash_table.h>
+#include <sphinxbase/strfuncs.h>
 
 typedef uint32 word_id_t;
 #define WORD_NO_ID	(0xffffffff)

--- a/include/s3/s3lamb_io.h
+++ b/include/s3/s3lamb_io.h
@@ -57,6 +57,7 @@ extern "C" {
 #define LAMBDACNT_FILE_VERSION "1.0"
 
 #include <sphinxbase/prim_type.h>
+#include <sphinxbase/bio.h>
 
 int
 s3lamb_read(const char *fn,

--- a/include/s3/s3map_io.h
+++ b/include/s3/s3map_io.h
@@ -53,6 +53,7 @@ extern "C" {
 #endif
 
 #include <sphinxbase/prim_type.h>
+#include <sphinxbase/bio.h>
 
 #include <stdlib.h>
 

--- a/include/s3/s3mixw_io.h
+++ b/include/s3/s3mixw_io.h
@@ -56,6 +56,7 @@ extern "C" {
 
 #include <sphinxbase/prim_type.h>
 #include <s3/s3.h>
+#include <sphinxbase/bio.h>
 
 int
 s3mixw_read(const char *fn,

--- a/include/s3/segdmp.h
+++ b/include/s3/segdmp.h
@@ -55,6 +55,7 @@ extern "C" {
 #include <sphinxbase/prim_type.h>
 #include <s3/acmod_set.h>
 #include <s3/vector.h>
+#include "segdmp.h"
 
 typedef enum {
     SEGDMP_TYPE_VQ,

--- a/src/libs/libio/s3lamb_io.c
+++ b/src/libs/libio/s3lamb_io.c
@@ -138,7 +138,7 @@ s3lamb_write(const char *fn,
 	return S3_ERROR;
     }
 
-    if (bio_fwrite(&chksum, sizeof(uint32), 1, fp, &ignore) != 1) {
+    if (bio_fwrite(&chksum, sizeof(uint32), 1, fp, 0, &ignore) != 1) {
 	s3close(fp);
 
 	return S3_ERROR;
@@ -239,7 +239,7 @@ s3lambcnt_write(const char *fn,
 	return S3_ERROR;
     }
 
-    if (bio_fwrite(&chksum, sizeof(uint32), 1, fp, &ignore) != 1) {
+    if (bio_fwrite(&chksum, sizeof(uint32), 1, fp, 0, &ignore) != 1) {
 	s3close(fp);
 
 	return S3_ERROR;

--- a/src/libs/libio/s3map_io.c
+++ b/src/libs/libio/s3map_io.c
@@ -143,7 +143,7 @@ s3map_write(const char *fn,
     if (fp == NULL)
 	return S3_ERROR;
 
-    if (bio_fwrite(&n_rng, sizeof(uint32), 1, fp, &chksum) != 1) {
+    if (bio_fwrite(&n_rng, sizeof(uint32), 1, fp, 0, &chksum) != 1) {
 	s3close(fp);
 
 	return S3_ERROR;
@@ -159,7 +159,7 @@ s3map_write(const char *fn,
 	return S3_ERROR;
     }
 
-    if (bio_fwrite(&chksum, sizeof(uint32), 1, fp, &ignore) != 1) {
+    if (bio_fwrite(&chksum, sizeof(uint32), 1, fp, 0, &ignore) != 1) {
 	s3close(fp);
 
 	return S3_ERROR;

--- a/src/libs/libio/segdmp.c
+++ b/src/libs/libio/segdmp.c
@@ -49,6 +49,7 @@
 #include <sphinxbase/ckd_alloc.h>
 #include <sphinxbase/cmd_ln.h>
 #include <sphinxbase/err.h>
+#include <sphinxbase/bio.h>
 
 #include <s3/segdmp.h>
 #include <s3/s3io.h>
@@ -132,7 +133,7 @@ write_seg_inorder(FILE *fp,
 
     for (cur = s; cur;) {
 	l = frame_sz * cur->len;
-	if (bio_fwrite((void *)&frm_buf[cur->idx], 1, l, fp, &ignore) != l) {
+	if (bio_fwrite((void *)&frm_buf[cur->idx], 1, l, fp, 0, &ignore) != l) {
 	    E_ERROR_SYSTEM("Unable to write to dump file\n");
 	    
 	    return S3_ERROR;
@@ -294,7 +295,7 @@ write_idx(uint32 part)
     uint32 onefrm;
     uint32 i, j, ttt, n;
 
-    if (bio_fwrite(&n_id, sizeof(uint32), 1, idx_fp[part], &ignore) != 1) {
+    if (bio_fwrite(&n_id, sizeof(uint32), 1, idx_fp[part], 0, &ignore) != 1) {
 	E_FATAL_SYSTEM("Unable to write index file");
 
 	return S3_ERROR;
@@ -306,13 +307,13 @@ write_idx(uint32 part)
 	onefrm = FALSE;
 
     /* Write one frame per segment flag */
-    if (bio_fwrite(&onefrm, sizeof(uint32), 1, idx_fp[part], &ignore) != 1) {
+    if (bio_fwrite(&onefrm, sizeof(uint32), 1, idx_fp[part], 0, &ignore) != 1) {
 	E_FATAL_SYSTEM("Unable to write index file");
 
 	return S3_ERROR;
     }
 
-    if (bio_fwrite(&frame_sz, sizeof(uint32), 1, idx_fp[part], &ignore) != 1) {
+    if (bio_fwrite(&frame_sz, sizeof(uint32), 1, idx_fp[part], 0, &ignore) != 1) {
 	E_FATAL_SYSTEM("Unable to write index file");
 
 	return S3_ERROR;
@@ -328,31 +329,31 @@ write_idx(uint32 part)
 
     i = ttt;
 
-    if (bio_fwrite(&i, sizeof(uint32), 1, idx_fp[part], &ignore) != 1) {
+    if (bio_fwrite(&i, sizeof(uint32), 1, idx_fp[part], 0, &ignore) != 1) {
 	E_FATAL_SYSTEM("Unable to write index file");
 
 	return S3_ERROR;
     }
-    if (bio_fwrite(&n, sizeof(uint32), 1, idx_fp[part], &ignore) != 1) {
+    if (bio_fwrite(&n, sizeof(uint32), 1, idx_fp[part], 0, &ignore) != 1) {
 	E_FATAL_SYSTEM("Unable to write index file");
 
 	return S3_ERROR;
     }
 
     for (; (i < n_id) && (id_part[i] == part); i++) {
-	if (bio_fwrite(&n_seg[i], sizeof(uint32), 1, idx_fp[part], &ignore) != 1) {
+	if (bio_fwrite(&n_seg[i], sizeof(uint32), 1, idx_fp[part], 0, &ignore) != 1) {
 	    E_FATAL_SYSTEM("Unable to write index file");
 	    
 	    return S3_ERROR;
 	}
-	if (bio_fwrite(&id_off[i], sizeof(uint32), 1, idx_fp[part], &ignore) != 1) {
+	if (bio_fwrite(&id_off[i], sizeof(uint32), 1, idx_fp[part], 0, &ignore) != 1) {
 	    E_FATAL_SYSTEM("Unable to write index file");
 	    
 	    return S3_ERROR;
 	}
 	if (!onefrm) {
 	    for (j = 0; j < n_seg[i]; j++) {
-		if (bio_fwrite(&n_frame[i][j], sizeof(uint32), 1, idx_fp[part], &ignore) != 1) {
+		if (bio_fwrite(&n_frame[i][j], sizeof(uint32), 1, idx_fp[part], 0, &ignore) != 1) {
 		    E_FATAL_SYSTEM("Unable to write index file");
 		    
 		    return S3_ERROR;
@@ -589,7 +590,7 @@ segdmp_open_write(const char **dirs,		/* directories available for dump files */
 	    
 	    idx_fp[i] = s3open(idx_fn, "wb", NULL);
 	    
-	    if (bio_fwrite((int *)&data_type, sizeof(int), 1, idx_fp[i], &ignore) != 1) {
+	    if (bio_fwrite((int *)&data_type, sizeof(int), 1, idx_fp[i], 0, &ignore) != 1) {
 		E_FATAL_SYSTEM("unable to write seg dmp file");
 	    }
 	    if (write_idx(i) == S3_SUCCESS) {

--- a/src/programs/agg_seg/agg_all_seg.h
+++ b/src/programs/agg_seg/agg_all_seg.h
@@ -50,6 +50,7 @@
 
 #include <sphinxbase/prim_type.h>
 #include <sphinxbase/feat.h>
+#include <sphinxbase/bio.h>
 
 int
 agg_all_seg(feat_t *fcb,

--- a/src/programs/bw/main.c
+++ b/src/programs/bw/main.c
@@ -86,7 +86,7 @@
 static float32 lm_scale = 11.5;
 
 /* FIXME: Should go in libutil */
-static char *
+char *
 string_join(const char *base, ...)
 {
     va_list args;
@@ -1072,7 +1072,8 @@ lat_fwd_bwd(s3lattice_t *lat)
 	  lat->arc[i].beta = log_add(lat->arc[i].beta, 0);
 	}
 	else {
-	  if (lat->arc[id-1].good_arc == 1);
+	  if (lat->arc[id-1].good_arc == 1)
+        ;
 	  lat->arc[i].beta = log_add(lat->arc[i].beta, lat->arc[id-1].beta);
 	}
       }

--- a/src/programs/map_adapt/main.c
+++ b/src/programs/map_adapt/main.c
@@ -34,7 +34,7 @@
 #include <s3/s3acc_io.h>
 #include <s3/s3.h>
 #include <s3/ts2cb.h>
-
+#include <s3/s3ts2cb_io.h>
 #include <sphinxbase/matrix.h>
 #include <sphinxbase/err.h>
 


### PR DESCRIPTION
This fixes function references that had the wrong number of arguments (missing swap), and adds includes for implicitly defined functions. With this, it builds again.

Depends on https://github.com/cmusphinx/sphinxbase/pull/82
