### PR TITLE
More diagnostics do not uppercase

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,2 @@
+build
+dist

--- a/scripts/00.verify/verify_all.pl
+++ b/scripts/00.verify/verify_all.pl
@@ -88,7 +88,7 @@ my %phonelist_hash;
 	    my $phonetic = $2;
 	    my @phones = ($phonetic =~ m/(\S+)/g);
 	    for my $phone (@phones) {
-		$dict_phone_hash{uc($phone)}++;
+		$dict_phone_hash{$phone}++;
 	    }
 	}
 	$counter++;

--- a/scripts/decode/slave.pl
+++ b/scripts/decode/slave.pl
@@ -151,6 +151,7 @@ sub align_hyp {
     my ($wer, $ser, $word_total, $sent_total, $sent_err);
     open (OUT, "> $outfile") or die "Can't open $outfile for writing\n";
     my $cmdln = "perl \"$thisdir/word_align.pl\" $use_cer -i \"$ref\" \"$hyp\"";
+    print "$cmdln\n";
     $sent_total = 0;
     if (open (PIPE, "$cmdln 2>&1 |")) {
       while (<PIPE>) {

--- a/scripts/decode/slave.pl
+++ b/scripts/decode/slave.pl
@@ -106,9 +106,9 @@ sub condition_text {
 
   while (<IN>) {
     m/^(.*)\((\S+)\)\s*$/;
-# Make them uppercase
-    my $text = uc($1);
-    my $id = uc($2);
+# We no longer uppercase these by default
+    my $text = $1;
+    my $id = $2;
 # Removing leading spaces
     $text =~ s/^\s+//;
 # Removing trailing spaces

--- a/scripts/decode/word_align.pl
+++ b/scripts/decode/word_align.pl
@@ -54,6 +54,8 @@ while (defined(my $hyp_utt=<HYP>)){
 }
 close HYP;
 
+die "No hypotheses in: $hyp" unless %hyphash;
+
 open REF, "<$ref" or die "Failed to open $ref: $!";
 open HYP, "<$hyp" or die "Failed to open $hyp: $!";
 

--- a/scripts/decode/word_align.pl
+++ b/scripts/decode/word_align.pl
@@ -45,7 +45,10 @@ my ($ref, $hyp) = @ARGV;
 my ($total_cost, $total_words, $total_hyp);
 my ($total_ins, $total_del, $total_subst, $total_match);
 
-# Build hypotesis hash (lookup by uttid)
+print "ref: $ref\n";
+print "hyp: $hyp\n";
+
+# Build hypothesis hash (lookup by uttid)
 open HYP, "<$hyp" or die "Failed to open $hyp: $!";
 while (defined(my $hyp_utt=<HYP>)){
     my $hyp_uttid;

--- a/templates/rm/scripts_pl/create_transcripts.pl
+++ b/templates/rm/scripts_pl/create_transcripts.pl
@@ -66,7 +66,7 @@ sub create_files {
 	    s,^/rm1/,,i;
 	    s/\.wav$//;
 	    my $uttid = basename($_);
-	    print OUTLSN "<s> " . $sents{uc($uttid)} . " </s> ($uttid)\n";
+	    print OUTLSN "<s> " . $sents{$uttid} . " </s> ($uttid)\n";
 	    print OUTCTL "$_\n";
 	}
     }


### PR DESCRIPTION
Uppercasing the phone names by default prevents phonesets like XSAMPA from being used, and there's no need to assume the file names are uppercase only. Also, emit a little more info while building models.