### PR TITLE
Make an option in config for not folding case in phonemes

### DIFF
--- a/etc/sphinx_train.cfg
+++ b/etc/sphinx_train.cfg
@@ -99,6 +99,9 @@ $CFG_LISTOFFILES    = "$CFG_LIST_DIR/${CFG_DB_NAME}_train.fileids";
 $CFG_TRANSCRIPTFILE = "$CFG_LIST_DIR/${CFG_DB_NAME}_train.transcription";
 $CFG_FEATPARAMS     = "$CFG_LIST_DIR/feat.params";
 
+# (yes/no) Allow cased phone and word names; otherwise, forces upper case
+$CFG_CASEDSYMBOLS = 'no';
+
 # Variables used in characterizing models
 
 $CFG_HMM_TYPE = '.cont.'; # Sphinx 4, PocketSphinx

--- a/scripts/00.verify/verify_all.pl
+++ b/scripts/00.verify/verify_all.pl
@@ -88,7 +88,11 @@ my %phonelist_hash;
 	    my $phonetic = $2;
 	    my @phones = ($phonetic =~ m/(\S+)/g);
 	    for my $phone (@phones) {
-		$dict_phone_hash{uc($phone)}++;
+	        # For case-insensitive file systems, forcing case can be helpful
+	        if ($ST::CFG_CASEDSYMBOLS ne 'yes') {
+	            $phone = uc($phone)
+	        }
+	        $dict_phone_hash{$phone}++;
 	    }
 	}
 	$counter++;

--- a/scripts/decode/slave.pl
+++ b/scripts/decode/slave.pl
@@ -106,9 +106,13 @@ sub condition_text {
 
   while (<IN>) {
     m/^(.*)\((\S+)\)\s*$/;
+    my $text = $1;
+    my $id = $2;
+    if ($ST::CFG_CASEDSYMBOLS ne 'yes') {
 # Make them uppercase
-    my $text = uc($1);
-    my $id = uc($2);
+      $text = uc($text);
+      $id = uc($id);
+    }
 # Removing leading spaces
     $text =~ s/^\s+//;
 # Removing trailing spaces

--- a/scripts/decode/word_align.pl
+++ b/scripts/decode/word_align.pl
@@ -45,7 +45,7 @@ my ($ref, $hyp) = @ARGV;
 my ($total_cost, $total_words, $total_hyp);
 my ($total_ins, $total_del, $total_subst, $total_match);
 
-# Build hypotesis hash (lookup by uttid)
+# Build hypothesis hash (lookup by uttid)
 open HYP, "<$hyp" or die "Failed to open $hyp: $!";
 while (defined(my $hyp_utt=<HYP>)){
     my $hyp_uttid;
@@ -53,6 +53,8 @@ while (defined(my $hyp_utt=<HYP>)){
     $hyphash{$hyp_uttid} = "$hyp_utt ($hyp_uttid)";
 }
 close HYP;
+
+die "No hypotheses in: $hyp" unless %hyphash;
 
 open REF, "<$ref" or die "Failed to open $ref: $!";
 open HYP, "<$hyp" or die "Failed to open $hyp: $!";

--- a/templates/rm/scripts_pl/create_transcripts.pl
+++ b/templates/rm/scripts_pl/create_transcripts.pl
@@ -66,7 +66,8 @@ sub create_files {
 	    s,^/rm1/,,i;
 	    s/\.wav$//;
 	    my $uttid = basename($_);
-	    print OUTLSN "<s> " . $sents{uc($uttid)} . " </s> ($uttid)\n";
+
+	    print OUTLSN "<s> " . $sents{$uttid} . " </s> ($uttid)\n";
 	    print OUTCTL "$_\n";
 	}
     }


### PR DESCRIPTION
By default, this leaves the behavior as it was, but adds CFG_CASEDSYMBOLS option (by default "no", must be "yes" to do anything) to sphinx_train.cfg. This opens up the possibility of using phone sets like XSAMPA which have phonemes that differ only in case, such as u / U or z / Z on systems that have case-dependent file systems such as linux (or macOS when formatted as case-dependent).

Note that case-independent file systems can have collisions between casing variants irrespective of this change, and there is nothing that warns a user if there is a conflict. This change does nothing to alter the fact that the user needs to be aware of the phone sets. I would argue that the default should not fold case, because case-independent systems don't care anyway, and by forcing case generality is removed. However, to accommodate comments on a prior PR, and to leave the behavior unchanged by default, this change has to be invoked explicitly.