### PR TITLE
Use consistent shebang for python

### DIFF
--- a/python/cmusphinx/lat2dot.py
+++ b/python/cmusphinx/lat2dot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/scripts/0000.g2p_train/calculateER.py
+++ b/scripts/0000.g2p_train/calculateER.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) [2012-], Josef Robert Novak
 # All rights reserved.

--- a/scripts/0000.g2p_train/evaluate.py
+++ b/scripts/0000.g2p_train/evaluate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) [2012-], Josef Robert Novak
 # All rights reserved.

--- a/scripts/decode/word_align.py
+++ b/scripts/decode/word_align.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/scripts/sphinxtrain
+++ b/scripts/sphinxtrain
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import print_function
 


### PR DESCRIPTION
In its current state, `sphinxtrain` has inconsistencies in the shebangs used for Python files. 30 of the files use `#!/usr/bin/env python` while 5 use `#!/usr/bin/python`. At least one of those files cause issues both on macOS and Debian/Alpine. On macOS, the `sphinxtrain` executable fails because it cannot find the Python executable (`zsh: /usr/local/bin/sphinxtrain: bad interpreter: /usr/bin/python: no such file or directory
`) wheras on Debian/Alpine the `sphinxtrain` command can't even be found because of this. With the changes in this PR, `sphinxtrain` can be found/executed on the Linux distros and on macOS.