### PR TITLE
Add -sox flag to sphinx_fe to convert files with SoX

### DIFF
--- a/scripts/000.comp_feat/make_feats.pl
+++ b/scripts/000.comp_feat/make_feats.pl
@@ -73,11 +73,14 @@ $logfile = "$log_dir/${exptid}-${part}-${npart}.log";
 
 # Defines input audio format
 $wavtype = $ST::CFG_WAVFILE_TYPE unless defined($wavtype);
-$nist = "no"; $raw = "no"; $mswav = "no";
+my $nist = "no";
+my $raw = "no";
+my $mswav = "no";
+my $sox = "no";
 if ($wavtype eq 'nist') {$nist = "yes";}
-if ($wavtype eq 'raw') {$raw = "yes";}
-if ($wavtype eq 'mswav') {$mswav = "yes";}
-
+elsif ($wavtype eq 'raw') {$raw = "yes";}
+elsif ($wavtype eq 'mswav') {$mswav = "yes";}
+else { $sox = "yes";}
 
 my @warp_args;
 if (defined($warp)) {
@@ -111,6 +114,7 @@ my $rv = RunTool('sphinx_fe', $logfile, $ctlcount,
 		  -nist => $nist,
 		  -raw => $raw,
 		  -mswav => $mswav,
+		  -sox => $sox,
 		  -samprate => $ST::CFG_WAVFILE_SRATE,
 		  -lowerf => $ST::CFG_LO_FILT,
 		  -upperf => $ST::CFG_HI_FILT,

--- a/src/programs/sphinx_fe/cmd_ln_defn.h
+++ b/src/programs/sphinx_fe/cmd_ln_defn.h
@@ -155,6 +155,11 @@ static arg_t defn[] = {
     "yes",
     "Create missing subdirectories in output directory" },
 
+  { "-sox",
+    ARG_BOOLEAN,
+    "no",
+    "Input is anything SoX supports, use sox to convert it" },
+
   { "-sph2pipe",
     ARG_BOOLEAN,
     "no",


### PR DESCRIPTION
To use in SphinxTrain simply set $CFG_WAVEFILE_TYPE to ... anything except "mswav", "nist", or "raw".

SoX should be able to handle most things (notably FLAC and MP3 for LibriSpeech and CommonVoice) although it appears that it doesn't do Opus yet, unfortunately.  This will need to get added as well, possibly in this PR.