### PR TITLE
Fix stalled Queue::POSIX training

### DIFF
--- a/scripts/01.lda_train/slave_lda.pl
+++ b/scripts/01.lda_train/slave_lda.pl
@@ -109,6 +109,8 @@ if ($iter eq 'N') {
 	push @deps, LaunchScript("bw.lda.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, 'yes']);
     }
     LaunchScript("lda", "lda_train.pl", \@deps);
+    # Explicitly wait for the BW scripts to avoid zombies
+    WaitForScript(@deps);
 }
 else {
     my @deps;
@@ -116,6 +118,8 @@ else {
 	push @deps, LaunchScript("bw.lda.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, 'no']);
     }
     LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts], \@deps);
+    # Explicitly wait for the BW scripts to avoid zombies
+    WaitForScript(@deps);
     # On the first iteration, wait for the LDA stuff to complete
     my $lda_log = File::Spec->catfile($logdir, "$ST::CFG_EXPTNAME.lda_train.log");
     if ($iter == 1) {

--- a/scripts/01.lda_train/slave_lda.pl
+++ b/scripts/01.lda_train/slave_lda.pl
@@ -108,8 +108,8 @@ if ($iter eq 'N') {
     for (my $i=1; $i<=$n_parts; $i++) {
 	push @deps, LaunchScript("bw.lda.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, 'yes']);
     }
-    LaunchScript("lda", "lda_train.pl", \@deps);
-    # Explicitly wait for the BW scripts to avoid zombies
+    push @deps, LaunchScript("lda", "lda_train.pl", \@deps);
+    # Explicitly wait for everything
     WaitForScript(@deps);
 }
 else {
@@ -117,40 +117,35 @@ else {
     for (my $i=1; $i<=$n_parts; $i++) {
 	push @deps, LaunchScript("bw.lda.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, 'no']);
     }
-    LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts], \@deps);
+    push @deps, LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts], \@deps);
     # Explicitly wait for the BW scripts to avoid zombies
     WaitForScript(@deps);
-    # On the first iteration, wait for the LDA stuff to complete
+    # Report success or failure
     my $lda_log = File::Spec->catfile($logdir, "$ST::CFG_EXPTNAME.lda_train.log");
     if ($iter == 1) {
-	# This is kind of a lousy way to do it, but oh well...
-	my $interval = 5;
-	while (1) {
-	    # Look for an error
-	    for ($iter = 1; $iter <= $ST::CFG_MAX_ITERATIONS; ++$iter) {
-		my $norm_log = File::Spec->catfile($logdir,
-						   "$ST::CFG_EXPTNAME.$iter.norm.log");
-		if (open LOG, "<$norm_log") {
-		    if (/failed/ or /Aborting/) {
-			LogError("Training failed in iteration $iter");
-			exit 1;
-		    }
-		}
-	    }
-	    if (open LOG, "<$lda_log") {
-		while (<LOG>) {
-		    if (/failed/) {
-			LogError("LDA Training failed");
-			exit 1;
-		    }
-		    elsif (/complete/) {
-			Log("LDA Training completed", 'result');
-			exit 0;
-		    }
-		}
-	    }
-	    sleep $interval;
-	}
+        # Look for an error
+        for ($iter = 1; $iter <= $ST::CFG_MAX_ITERATIONS; ++$iter) {
+            my $norm_log = File::Spec->catfile($logdir,
+                                               "$ST::CFG_EXPTNAME.$iter.norm.log");
+            if (open LOG, "<$norm_log") {
+                if (/failed/ or /Aborting/) {
+                    LogError("Training failed in iteration $iter");
+                    exit 1;
+                }
+            }
+        }
+        if (open LOG, "<$lda_log") {
+            while (<LOG>) {
+                if (/failed/) {
+                    LogError("LDA Training failed");
+                    exit 1;
+                }
+                elsif (/complete/) {
+                    Log("LDA Training completed", 'result');
+                    exit 0;
+                }
+            }
+        }
     }
 }
 

--- a/scripts/01.lda_train/slave_lda.pl
+++ b/scripts/01.lda_train/slave_lda.pl
@@ -124,7 +124,6 @@ else {
     my $lda_log = File::Spec->catfile($logdir, "$ST::CFG_EXPTNAME.lda_train.log");
     if ($iter == 1) {
 	# This is kind of a lousy way to do it, but oh well...
-	local $SIG{CHLD} = sub { wait; };
 	my $interval = 5;
 	while (1) {
 	    # Look for an error

--- a/scripts/02.mllt_train/slave_mllt.pl
+++ b/scripts/02.mllt_train/slave_mllt.pl
@@ -116,6 +116,8 @@ else {
 	push @deps, LaunchScript("bw.mllt.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, 'no']);
     }
     LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts], \@deps);
+    # Explicitly wait for the BW scripts to avoid zombies
+    WaitForScript(@deps);
     # On the first iteration, wait for the MLLT stuff to complete
     my $mllt_log = File::Spec->catfile($logdir, "$ST::CFG_EXPTNAME.mllt_train.log");
     if ($iter == 1) {

--- a/scripts/02.mllt_train/slave_mllt.pl
+++ b/scripts/02.mllt_train/slave_mllt.pl
@@ -109,6 +109,8 @@ if ($iter eq 'N') {
 	push @deps, LaunchScript("bw.mllt.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, 'yes']);
     }
     LaunchScript("mllt", "mllt_train.pl", \@deps);
+    # Explicitly wait for the BW scripts to avoid zombies
+    WaitForScript(@deps);
 }
 else {
     my @deps;
@@ -122,7 +124,6 @@ else {
     my $mllt_log = File::Spec->catfile($logdir, "$ST::CFG_EXPTNAME.mllt_train.log");
     if ($iter == 1) {
 	# This is kind of a lousy way to do it, but oh well...
-	local $SIG{CHLD} = sub { wait; };
 	my $interval = 5;
 	while (1) {
 	    # Look for an error

--- a/scripts/10.falign_ci_hmm/slave_convg.pl
+++ b/scripts/10.falign_ci_hmm/slave_convg.pl
@@ -109,12 +109,10 @@ for (my $i=1; $i<=$n_parts; $i++)
 {
     push @jobs, LaunchScript("bw.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, $n_gau])
 }
-my $norm = LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts, $n_gau], \@jobs);
-# Explicitly wait for them all to complete to avoid zombies
-push @jobs, $norm;
-foreach (@jobs) {
-    $ST::Q->waitfor_job($_);
-}
+LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts, $n_gau], \@jobs);
+# Explicitly wait for the BW scripts to avoid zombies
+WaitForScript(@jobs);
+
 # For the first iteration (i.e. the one that was called from the
 # command line or a parent script), wait until completion or error
 if ($iter == 1 && $n_gau == $ST::CFG_INITIAL_NUM_DENSITIES) {

--- a/scripts/10.falign_ci_hmm/slave_convg.pl
+++ b/scripts/10.falign_ci_hmm/slave_convg.pl
@@ -104,12 +104,17 @@ if ($iter == 1 and $n_gau == $ST::CFG_INITIAL_NUM_DENSITIES) {
 
 # Call baum_welch with iter part and n_parts,
 # once done call norm_and_lauchbw.pl
-my @deps;
+my @jobs;
 for (my $i=1; $i<=$n_parts; $i++)
 {
-    push @deps, LaunchScript("bw.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, $n_gau])
+    push @jobs, LaunchScript("bw.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, $n_gau])
 }
-LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts, $n_gau], \@deps);
+my $norm = LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts, $n_gau], \@jobs);
+# Explicitly wait for them all to complete to avoid zombies
+push @jobs, $norm;
+foreach (@jobs) {
+    $ST::Q->waitfor_job($_);
+}
 # For the first iteration (i.e. the one that was called from the
 # command line or a parent script), wait until completion or error
 if ($iter == 1 && $n_gau == $ST::CFG_INITIAL_NUM_DENSITIES) {

--- a/scripts/20.ci_hmm/slave_convg.pl
+++ b/scripts/20.ci_hmm/slave_convg.pl
@@ -134,12 +134,9 @@ for (my $i=1; $i<=$n_parts; $i++)
 {
     push @jobs, LaunchScript("bw.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, $n_gau])
 }
-my $norm = LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts, $n_gau], \@jobs);
-# Explicitly wait for them all to complete to avoid zombies
-push @jobs, $norm;
-foreach (@jobs) {
-    $ST::Q->waitfor_job($_);
-}
+LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts, $n_gau], \@jobs);
+# Explicitly wait for the BW scripts to avoid zombies
+WaitForScript(@jobs);
 
 # For the first iteration (i.e. the one that was called from the
 # command line or a parent script), wait until completion or error

--- a/scripts/20.ci_hmm/slave_convg.pl
+++ b/scripts/20.ci_hmm/slave_convg.pl
@@ -129,12 +129,18 @@ if (defined($ST::CFG_PHSEG_DIR) and ! -d $ST::CFG_PHSEG_DIR) {
 
 # Call baum_welch with iter part and n_parts,
 # once done call norm_and_lauchbw.pl
-my @deps;
+my @jobs;
 for (my $i=1; $i<=$n_parts; $i++)
 {
-    push @deps, LaunchScript("bw.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, $n_gau])
+    push @jobs, LaunchScript("bw.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts, $n_gau])
 }
-LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts, $n_gau], \@deps);
+my $norm = LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts, $n_gau], \@jobs);
+# Explicitly wait for them all to complete to avoid zombies
+push @jobs, $norm;
+foreach (@jobs) {
+    $ST::Q->waitfor_job($_);
+}
+
 # For the first iteration (i.e. the one that was called from the
 # command line or a parent script), wait until completion or error
 if ($iter == 1 && $n_gau == $ST::CFG_INITIAL_NUM_DENSITIES) {

--- a/scripts/30.cd_hmm_untied/slave_convg.pl
+++ b/scripts/30.cd_hmm_untied/slave_convg.pl
@@ -112,12 +112,10 @@ for (my $i=1; $i<=$n_parts; $i++)
 {
     push @jobs, LaunchScript("bw.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts])
 }
-my $norm = LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts], \@jobs);
-# Explicitly wait for them all to complete to avoid zombies
-push @jobs, $norm;
-foreach (@jobs) {
-    $ST::Q->waitfor_job($_);
-}
+LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts], \@jobs);
+# Explicitly wait for the BW scripts to avoid zombies
+WaitForScript(@jobs);
+
 # For the first iteration (i.e. the one that was called from the
 # command line or a parent script), wait until completion or error
 if ($iter == 1) {

--- a/scripts/30.cd_hmm_untied/slave_convg.pl
+++ b/scripts/30.cd_hmm_untied/slave_convg.pl
@@ -107,12 +107,17 @@ if ($iter == 1) {
 
 # Call baum_welch with iter part and n_parts,
 # once done call norm_and_lauchbw.pl
-my @deps;
+my @jobs;
 for (my $i=1; $i<=$n_parts; $i++)
 {
-    push @deps, LaunchScript("bw.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts])
+    push @jobs, LaunchScript("bw.$iter.$i", ['baum_welch.pl', $iter, $i, $n_parts])
 }
-LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts], \@deps);
+my $norm = LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts], \@jobs);
+# Explicitly wait for them all to complete to avoid zombies
+push @jobs, $norm;
+foreach (@jobs) {
+    $ST::Q->waitfor_job($_);
+}
 # For the first iteration (i.e. the one that was called from the
 # command line or a parent script), wait until completion or error
 if ($iter == 1) {

--- a/scripts/50.cd_hmm_tied/slave_convg.pl
+++ b/scripts/50.cd_hmm_tied/slave_convg.pl
@@ -103,12 +103,17 @@ if (($iter == 1) && (($n_gau == $ST::CFG_INITIAL_NUM_DENSITIES) || ($ST::CFG_HMM
 
 # Call baum_welch with iter part and n_parts,
 # once done call norm_and_lauchbw.pl
-my @deps;
+my @jobs;
 for (my $i=1; $i<=$n_parts; $i++)
 {
-    push @deps, LaunchScript("bw.$n_gau.$iter.$i", ['baum_welch.pl', $n_gau, $iter, $i, $n_parts]);
+    push @jobs, LaunchScript("bw.$n_gau.$iter.$i", ['baum_welch.pl', $n_gau, $iter, $i, $n_parts]);
 }
-LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $n_gau, $iter, $n_parts], \@deps);
+my $norm = LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $n_gau, $iter, $n_parts], \@jobs);
+# Explicitly wait for them all to complete to avoid zombies
+push @jobs, $norm;
+foreach (@jobs) {
+    $ST::Q->waitfor_job($_);
+}
 # For the first iteration (i.e. the one that was called from the
 # command line or a parent script), wait until completion or error
 my $return_value = 0;

--- a/scripts/50.cd_hmm_tied/slave_convg.pl
+++ b/scripts/50.cd_hmm_tied/slave_convg.pl
@@ -108,12 +108,10 @@ for (my $i=1; $i<=$n_parts; $i++)
 {
     push @jobs, LaunchScript("bw.$n_gau.$iter.$i", ['baum_welch.pl', $n_gau, $iter, $i, $n_parts]);
 }
-my $norm = LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $n_gau, $iter, $n_parts], \@jobs);
-# Explicitly wait for them all to complete to avoid zombies
-push @jobs, $norm;
-foreach (@jobs) {
-    $ST::Q->waitfor_job($_);
-}
+LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $n_gau, $iter, $n_parts], \@jobs);
+# Explicitly wait for the BW scripts to avoid zombies
+WaitForScript(@jobs);
+
 # For the first iteration (i.e. the one that was called from the
 # command line or a parent script), wait until completion or error
 my $return_value = 0;

--- a/scripts/65.mmie_train/slave_convg.pl
+++ b/scripts/65.mmie_train/slave_convg.pl
@@ -173,6 +173,8 @@ for (my $i=1; $i<=$n_parts; $i++)
 }
 
 LaunchScript("norm.$iter", ['norm_and_launchbw.pl', $iter, $n_parts], \@deps);
+# Explicitly wait for the BW scripts to avoid zombies
+WaitForScript(@deps);
 
 # For the first iteration (i.e. the one that was called from the
 # command line or a parent script), wait until completion or error

--- a/scripts/80.mllr_adapt/slave_adapt.pl
+++ b/scripts/80.mllr_adapt/slave_adapt.pl
@@ -92,5 +92,7 @@ while (defined(my $file = readdir OUTDIR)) {
 				     $spk, "$base.fileids", "$base.transcription"]);
 	# Launch an adapt job which runs afterwards
 	LaunchScript("mllr.$spk", ['mllr_solve.pl', $spk], [$job]);
+        # Explicitly wait for the BW script to avoid zombies
+        WaitForScript($job);
     }
 }

--- a/scripts/lib/Queue/POSIX.pm
+++ b/scripts/lib/Queue/POSIX.pm
@@ -61,8 +61,6 @@ sub submit_job {
 	return $pid;
     }
     else {
-	# Detach from parent process
-	setsid();
 	if (defined($job->{outfile})) {
 	    open STDOUT, ">$job->{outfile}" or die "Failed to open $job->{outfile}: $!";
 	}

--- a/scripts/lib/SphinxTrain/Util.pm
+++ b/scripts/lib/SphinxTrain/Util.pm
@@ -443,18 +443,14 @@ sub LaunchScript {
 }
 
 sub WaitForScript {
-    my $id = shift;
-    return $ST::Q->waitfor_job($id);
+    foreach my $id (@_) {
+        $ST::Q->waitfor_job($id);
+    }
 }
 
 sub WaitForConvergence {
     my $logdir = shift;
     my $interval = shift;
-
-    # For some reason (probably due to stupidity of system()), we
-    # can't do this globally or in Queue::POSIX, but we need it here
-    # (hopefully it does nothing on Windows)
-    local $SIG{CHLD} = sub { wait; };
 
     $interval = 5 unless defined($interval);
     # Wait for training to complete (FIXME: This needs to be more robust)
@@ -496,11 +492,6 @@ sub WaitForConvergence {
 sub TiedWaitForConvergence {
     my $logdir = shift;
     my $interval = shift;
-
-    # For some reason (probably due to stupidity of system()), we
-    # can't do this globally or in Queue::POSIX, but we need it here
-    # (hopefully it does nothing on Windows)
-    local $SIG{CHLD} = sub { wait; };
 
     $interval = 5 unless defined($interval);
     # Wait for training to complete (FIXME: This needs to be more robust)

--- a/scripts/lib/SphinxTrain/Util.pm
+++ b/scripts/lib/SphinxTrain/Util.pm
@@ -553,11 +553,6 @@ sub WaitForMMIEConverge {
   my $logdir = shift;
   my $interval = shift;
 
-  # For some reason (probably due to stupidity of system()), we
-  # can't do this globally or in Queue::POSIX, but we need it here
-  # (hopefully it does nothing on Windows)
-  local $SIG{CHLD} = sub { wait; };
-
   $interval = 5 unless defined($interval);
   # Wait for training to complete (FIXME: This needs to be more robust)
   my $maxiter = 0;


### PR DESCRIPTION
Fixes #33 - the problem wasn't actually TiedWaitForConvergence(), which quite innocently sits around reading log files until the end of time.  This is still arguably not a great idea, but the problem was actually `norm_and_launch_bw.pl` which was "waiting" for `baum_welch.pl` jobs which had stopped living and become mixed-up zombies.

This is a consequence of trying to fit a grid scheduler workflow onto processes, which is quite imperfect, because of the absolute need to `wait()` or `waitpid()` on a process *from its parent* rather than from whatever process might be depending on its completion.  The parent (which is `slave_convg.pl`) wasn't doing that.  So I made it explicitly do that.

You might think that just setting a global `SIGCHLD` handler before launching the darn things would solve the problem but... *sigh* for whatever reason, that doesn't work.  And setting a handler *after* launching them is obviously wrong.

This shouldn't really slow down training because we have to wait for them all somewhere anyway.  It *should* also be okay for batch scheduling systems though it might be a bit slow.