### PR TITLE
Minimally fix MLLT

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -46,7 +46,9 @@ cmusphinx/mllr.py				\
 cmusphinx/prune_mixw.py				\
 cmusphinx/corpus.py				\
 cmusphinx/lat_rescore.py			\
-cmusphinx/s3gaucnt.py				\
+cmusphinx/s3gaucnt.py
+
+EXTRA_DIST = $(nobase_scripts_SCRIPTS)		\
 test/test_corpus.py				\
 test/test_s2mfc.py				\
 test/test_s3file.py				\
@@ -84,5 +86,3 @@ test/test_s3dict.py				\
 test/test_hmm.py				\
 test/test_arpalm.py				\
 test/test_hypseg.py
-
-EXTRA_DIST = $(nobase_scripts_SCRIPTS)

--- a/python/cmusphinx/mllt.py
+++ b/python/cmusphinx/mllt.py
@@ -26,8 +26,7 @@ except ImportError:
           "Check that numpy and scipy are installed")
     sys.exit(1)
 
-from . import s3gaucnt
-from . import s3lda
+from cmusphinx import s3gaucnt, s3lda
 import getopt
 
 


### PR DESCRIPTION
Minimally.  We could do python properly, but we won't for the time being, instead we'll simply refrain from installing too much extra junk, and go back to using absolute packages.