### PR TITLE
Bake multiple lexical pronunciation into baum-welch

### DIFF
--- a/etc/sphinx_train.cfg
+++ b/etc/sphinx_train.cfg
@@ -204,6 +204,20 @@ $CFG_FORCE_ALIGN_BEAM = 1e-60;
 # 11.force_align. Beam for multipron_align follows $CFG_FORCE_ALIGN_BEAM (else 1e-308).
 $CFG_MULTIPRON = 'yes';
 
+# Enable multi-pronunciation Baum-Welch training. When yes, every bw invocation
+# is passed -multipron yes; bw then builds the per-utterance training HMM as a
+# graph with parallel paths for every dictionary variant of each word, and the
+# forward/backward sums posterior over the variants. When no, the trainer
+# silently picks pronunciation variant [1] for every multi-pron word — the
+# historical SphinxTrain behavior.
+#
+# Independent of $CFG_MULTIPRON above. The two compose well and the recommended
+# setup is to keep both yes: stage 21 produces a transcript where high-confidence
+# tokens already carry an explicit (N) suffix (and so collapse to a single-variant
+# expansion in the graph builder), while the graph builder still branches on the
+# remaining un-disambiguated tokens during BW.
+$CFG_MULTIPRON_TRAINING = 'yes';
+
 # Second CI pass after multipron (stage 22): re-run stage-20 training with supervision
 # from the multipron transcript (GetLists selects it once the file from stage 21 exists).
 # Re-runs flat init and replaces the CI model directory—roughly doubles CI wall time.

--- a/include/s3/lexicon.h
+++ b/include/s3/lexicon.h
@@ -68,11 +68,20 @@ typedef struct lex_entry_str {
     char **phone;
     acmod_id_t *ci_acmod_id;
     uint32  phone_cnt;
+
+    /* Linked list of pronunciation variants of the same base word.
+     * Entries with full orthos "reading", "reading(2)", "reading(3)"
+     * share base word "reading" and are chained via this pointer.
+     * The chain head is what lexicon_lookup_variants() returns.
+     * Single-variant words have next_variant == NULL.
+     */
+    struct lex_entry_str *next_variant;
 } lex_entry_t;
 
 typedef struct lexicon_s {
     uint32 entry_cnt;
-    hash_table_t *ht;
+    hash_table_t *ht;       /* full ortho ("reading(2)") -> lex_entry_t */
+    hash_table_t *base_ht;  /* base word ("reading")     -> head of variant chain */
     acmod_set_t *phone_set;
 } lexicon_t;
 
@@ -86,6 +95,22 @@ lexicon_read(lexicon_t *prior_lex,
 lex_entry_t *
 lexicon_lookup(lexicon_t *lexicon,
 	       char *word);
+
+/* Return the head of the linked list of pronunciation variants for
+ * `base_word` (i.e. the word with any "(N)" suffix stripped).
+ * Returns NULL if no entries match. Walk the chain via
+ * entry->next_variant; ordering follows insertion order.
+ */
+lex_entry_t *
+lexicon_lookup_variants(lexicon_t *lexicon,
+                        const char *base_word);
+
+/* Small accessor helpers for callers that treat lex_entry_t as opaque. */
+const char *
+lex_entry_ortho(const lex_entry_t *e);
+
+lex_entry_t *
+lex_entry_next_variant(const lex_entry_t *e);
 
 void lexicon_free(lexicon_t *lexicon);
 

--- a/include/s3/phone_graph.h
+++ b/include/s3/phone_graph.h
@@ -1,0 +1,129 @@
+/**
+ * @file phone_graph.h
+ * @brief Phone-level utterance graph supporting multiple pronunciations per word.
+ *
+ * Replaces the implicit linear chain produced by mk_phone_list with
+ * an explicit graph that captures word-boundary branches.
+ *
+ * For utterances where every word has a single pronunciation, the
+ * resulting graph is a strict linear chain (n_next[i] = 1,
+ * next_idx[i][0] = i+1 for all i; mirror for prior), so callers that
+ * traverse via adjacency lists produce output identical to the
+ * historical mk_phone_list path.
+ *
+ * Triphone context expansion at multi-pron join points (where the
+ * first phone of the next word would otherwise have two different
+ * left contexts) is handled by the consumer (cvt2triphone_graph /
+ * state_seq_make_graph), not by this layer; this module only
+ * describes the combinatorial structure of the utterance.
+ */
+
+#ifndef PHONE_GRAPH_H
+#define PHONE_GRAPH_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <s3/acmod_set.h>
+#include <s3/lexicon.h>
+#include <sphinxbase/prim_type.h>
+
+typedef struct phone_graph_s {
+    /* Number of phone slots in the graph (sum over all variants of
+     * all words). For a single-pron utterance this equals the
+     * sum of word phone counts, matching the old `n_phone`. */
+    uint32 n;
+
+    /* Per-slot data, all length n. */
+    acmod_id_t *phone;     /* CI phone id at this slot */
+    char       *btw_mark;  /* nonzero if a word boundary follows this slot */
+
+    /* Per-slot successor lists. n_next[i] is the number of successor
+     * slots; next_idx[i] is an array of indices into this graph. For
+     * the linear case n_next[i] == 1 and next_idx[i][0] == i+1
+     * (last slot has n_next[i] == 0). At a multi-pron word boundary
+     * the previous word's last phone branches into the first phones
+     * of each variant of the next word; at a join the last phones of
+     * each variant fan in to the first phone of the next word. */
+    uint32  *n_next;
+    uint32 **next_idx;
+
+    /* Symmetric predecessor lists (n_prior[i] entries each). */
+    uint32  *n_prior;
+    uint32 **prior_idx;
+} phone_graph_t;
+
+/*
+ * Build a phone graph from a word sequence.
+ *
+ * For each word, all pronunciation variants registered in the
+ * lexicon's base-word index are included as parallel paths. The
+ * lexicon must have been read with the phase-1 base-word index
+ * populated (any lexicon_read() since the addition does).
+ *
+ * Behavior:
+ * - If `multipron` is FALSE, every word is expanded using exactly the
+ *   first variant (this matches the historical mk_phone_list
+ *   behavior; useful for parity testing).
+ * - If TRUE, every word with k variants contributes k parallel
+ *   pronunciation chains. Single-variant words still contribute one
+ *   linear chain.
+ *
+ * Returns NULL on lookup failure (the offending word is logged with
+ * E_WARN). The caller owns the returned phone_graph_t and must free
+ * it with phone_graph_free().
+ */
+phone_graph_t *
+mk_phone_graph(char **word,
+               uint32 n_word,
+               lexicon_t *lex,
+               int multipron);
+
+/* Allocate a graph with `n` slots and zeroed adjacency lists. The
+ * caller fills in `phone`, `btw_mark`, n_next/next_idx,
+ * n_prior/prior_idx. Used by mk_phone_graph and by tests. */
+phone_graph_t *
+phone_graph_alloc(uint32 n);
+
+/* Free a graph and all owned arrays. NULL-safe. */
+void
+phone_graph_free(phone_graph_t *graph);
+
+/* Diagnostic: print the graph in a readable form. */
+void
+phone_graph_print(const phone_graph_t *graph, acmod_set_t *acmod_set);
+
+/*
+ * Return a copy of `in` in which every slot has at most one distinct
+ * CI-phone predecessor — i.e. every slot has an unambiguous left
+ * context for triphone resolution. Where the input has a slot whose
+ * predecessors carry multiple distinct CI phones, that slot is
+ * duplicated once per distinct predecessor CI phone, and the
+ * predecessor edges are partitioned accordingly.
+ *
+ * For an input with no ambiguous-context slots (the single-pron
+ * case), the output is structurally identical to the input.
+ *
+ * The caller owns both `in` and the returned graph and must free
+ * each with phone_graph_free().
+ */
+phone_graph_t *
+phone_graph_split_contexts(const phone_graph_t *in);
+
+/*
+ * Walk an already-unambiguous-context graph (typically the output of
+ * phone_graph_split_contexts) and replace each slot's CI `phone`
+ * field with the triphone acmod_id appropriate for its (l, c, r,
+ * word_position) context. Slots with no successor get SIL as the
+ * right context (matching cvt2triphone()'s convention). Filler
+ * phones are left as their CI ids.
+ *
+ * Returns S3_SUCCESS or S3_ERROR.
+ */
+int
+cvt2triphone_graph(phone_graph_t *graph, acmod_set_t *acmod_set);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* PHONE_GRAPH_H */

--- a/include/s3/state_seq_graph.h
+++ b/include/s3/state_seq_graph.h
@@ -1,0 +1,53 @@
+/**
+ * @file state_seq_graph.h
+ * @brief Graph-aware utterance HMM builder for multi-pron training.
+ *
+ * Wraps state_seq_make() to operate on a phone_graph_t instead of a
+ * linear phone[] array. For a linear graph (all slots with n_next == 1
+ * and next_idx[i][0] == i+1) it produces a state_t array bit-identical
+ * to state_seq_make()'s output on the equivalent phone[] sequence.
+ *
+ * For a graph with multi-pron branches it produces a state graph
+ * where the non-emitting exit state of a phone slot fans out to the
+ * first states of all graph successors (and symmetrically for
+ * predecessors). Outgoing transition probabilities at fan-out points
+ * are initialized uniformly: 1/n_next[i] per arc.
+ *
+ * The graph is expected to have unambiguous triphone contexts before
+ * this is called: cvt2triphone_graph() handles any required slot
+ * duplication at multi-pron join points so each slot's `phone` field
+ * carries a single, fully-specified acmod_id (CI or triphone).
+ */
+
+#ifndef STATE_SEQ_GRAPH_H
+#define STATE_SEQ_GRAPH_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <s3/model_def_io.h>
+#include <s3/model_inventory.h>
+#include <s3/phone_graph.h>
+#include <s3/state.h>
+
+/*
+ * Build a state-level utterance HMM from a phone graph.
+ *
+ * On success, returns a freshly-allocated `state_t` array of length
+ * `*n_state`; caller is responsible for freeing it via
+ * `state_seq_free(state, *n_state)`. The model inventory's
+ * mixw_inverse / cb_inverse fields are updated (matching the
+ * existing state_seq_make's side effect).
+ *
+ * Returns NULL on error.
+ */
+state_t *
+state_seq_make_graph(uint32 *n_state,
+                     const phone_graph_t *graph,
+                     model_inventory_t *inv,
+                     model_def_t *mdef);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* STATE_SEQ_GRAPH_H */

--- a/scripts/01.lda_train/baum_welch.pl
+++ b/scripts/01.lda_train/baum_welch.pl
@@ -108,6 +108,11 @@ $ctl_counter = 1 unless ($ctl_counter);
 
 Log("Baum welch starting for LDA, iteration: $iter ($part of $npart)", 'result');
 
+my @extra_args;
+push(@extra_args, -multipron => 'yes')
+    if (defined($ST::CFG_MULTIPRON_TRAINING)
+        and $ST::CFG_MULTIPRON_TRAINING eq 'yes');
+
 my $return_value = RunTool
     ('bw', $logfile, $ctl_counter,
      -moddeffn => $moddeffn,
@@ -141,6 +146,7 @@ my $return_value = RunTool
      -diagfull => $fullvar,
      -feat => $ST::CFG_FEATURE,
      -ceplen => $ST::CFG_VECTOR_LENGTH,
+     @extra_args,
      -timing => "no");
 
 

--- a/scripts/02.mllt_train/baum_welch.pl
+++ b/scripts/02.mllt_train/baum_welch.pl
@@ -113,6 +113,10 @@ $ctl_counter = 1 unless ($ctl_counter);
 
 Log("Baum welch starting for MLLT, iteration: $iter ($part of $npart)", 'result');
 
+push(@extra_args, -multipron => 'yes')
+    if (defined($ST::CFG_MULTIPRON_TRAINING)
+        and $ST::CFG_MULTIPRON_TRAINING eq 'yes');
+
 my $return_value = RunTool
     ('bw', $logfile, $ctl_counter,
      -moddeffn => $moddeffn,

--- a/scripts/10.falign_ci_hmm/baum_welch.pl
+++ b/scripts/10.falign_ci_hmm/baum_welch.pl
@@ -133,6 +133,10 @@ if (-r $MLLT_FILE) {
 	 -ldadim => $ST::CFG_LDA_DIMENSION);
 }
 
+push(@feat_args, -multipron => 'yes')
+    if (defined($ST::CFG_MULTIPRON_TRAINING)
+        and $ST::CFG_MULTIPRON_TRAINING eq 'yes');
+
 my $return_value = RunTool
     ('bw', $logfile, $ctl_counter,
      -moddeffn => $moddeffn,

--- a/scripts/20.ci_hmm/baum_welch.pl
+++ b/scripts/20.ci_hmm/baum_welch.pl
@@ -148,6 +148,10 @@ until (-f $mixwfn) {
     sleep 1;
 }
 
+push(@feat_args, -multipron => 'yes')
+    if (defined($ST::CFG_MULTIPRON_TRAINING)
+        and $ST::CFG_MULTIPRON_TRAINING eq 'yes');
+
 my $return_value = RunTool
     ('bw', $logfile, $ctl_counter,
      -moddeffn => $moddeffn,

--- a/scripts/30.cd_hmm_untied/baum_welch.pl
+++ b/scripts/30.cd_hmm_untied/baum_welch.pl
@@ -123,6 +123,10 @@ $ctl_counter = 1 unless ($ctl_counter);
 
 Log ("Baum welch starting for iteration: $iter ($part of $npart) ", 'result');
 
+push(@feat_args, -multipron => 'yes')
+    if (defined($ST::CFG_MULTIPRON_TRAINING)
+        and $ST::CFG_MULTIPRON_TRAINING eq 'yes');
+
 my $return_value = RunTool
     ('bw', $logfile, $ctl_counter,
      -moddeffn => $moddeffn,

--- a/scripts/50.cd_hmm_tied/baum_welch.pl
+++ b/scripts/50.cd_hmm_tied/baum_welch.pl
@@ -145,6 +145,10 @@ $ctl_counter = 1 unless ($ctl_counter);
 Log("Baum welch starting for $n_gau Gaussian(s), iteration: $iter ($part of $npart)",
     'result');
 
+push(@extra_args, -multipron => 'yes')
+    if (defined($ST::CFG_MULTIPRON_TRAINING)
+        and $ST::CFG_MULTIPRON_TRAINING eq 'yes');
+
 my $return_value = RunTool
     ('bw', $logfile, $ctl_counter,
      -moddeffn => $moddeffn,

--- a/scripts/65.mmie_train/baum_welch.pl
+++ b/scripts/65.mmie_train/baum_welch.pl
@@ -136,6 +136,10 @@ if (-r $MLLT_FILE) {
 	 -ldadim => $ST::CFG_LDA_DIMENSION);
 }
 
+push(@extra_args, -multipron => 'yes')
+    if (defined($ST::CFG_MULTIPRON_TRAINING)
+        and $ST::CFG_MULTIPRON_TRAINING eq 'yes');
+
 my $return_value = RunTool
     ('bw', $logfile, $ctl_counter,
      -moddeffn => $moddeffn,

--- a/scripts/80.mllr_adapt/baum_welch.pl
+++ b/scripts/80.mllr_adapt/baum_welch.pl
@@ -115,6 +115,10 @@ $ctl_counter = 1 unless ($ctl_counter);
 
 Log("Baum welch starting for speaker $speaker", 'result');
 
+push(@extra_args, -multipron => 'yes')
+    if (defined($ST::CFG_MULTIPRON_TRAINING)
+        and $ST::CFG_MULTIPRON_TRAINING eq 'yes');
+
 my $return_value = RunTool
     ('bw', $logfile, $ctl_counter,
      -moddeffn => $moddeffn,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,9 @@ libs/libcommon/dtree.c
 libs/libcommon/ts2cb.c
 libs/libcommon/mk_sseq.c
 libs/libcommon/lexicon.c
+libs/libcommon/phone_graph.c
+libs/libcommon/phone_graph_triphone.c
+libs/libcommon/state_seq_graph.c
   )
 set(LAPACK_SRCS
 libs/libsphinxbase/util/slamch.c

--- a/src/libs/libcommon/lexicon.c
+++ b/src/libs/libcommon/lexicon.c
@@ -113,9 +113,76 @@ lexicon_t *lexicon_new()
 
     new->entry_cnt = 0;
 
-    new->ht = hash_table_new(64000, HASH_CASE_YES);
+    new->ht      = hash_table_new(64000, HASH_CASE_YES);
+    new->base_ht = hash_table_new(64000, HASH_CASE_YES);
 
     return new;
+}
+
+/*
+ * Compute the base word from a full ortho by stripping a trailing
+ * "(N)" suffix where N is one or more digits. Returns a newly
+ * malloc'd string; caller takes ownership.
+ *
+ * Examples:
+ *   "reading"     -> "reading"
+ *   "reading(2)"  -> "reading"
+ *   "f(x)"        -> "f(x)"          (parens but no trailing digits)
+ *   "wo(1rd)"     -> "wo(1rd)"       (not at end)
+ */
+static char *
+lex_base_word(const char *ortho)
+{
+    size_t n = strlen(ortho);
+    /* Need at least "x(N)" => 4 chars */
+    if (n >= 4 && ortho[n - 1] == ')') {
+	size_t i = n - 2;
+	size_t digits = 0;
+	while (i > 0 && ortho[i] >= '0' && ortho[i] <= '9') {
+	    ++digits;
+	    --i;
+	}
+	if (digits > 0 && ortho[i] == '(') {
+	    char *base = ckd_calloc(i + 1, sizeof(char));
+	    memcpy(base, ortho, i);
+	    base[i] = '\0';
+	    return base;
+	}
+    }
+    return ckd_salloc(ortho);
+}
+
+/* Add `entry` to the base-word index. If a chain already exists for
+ * the base word, walk to its tail and append. Otherwise, register a
+ * new chain head.
+ *
+ * The base_ht stores the chain head as its value; once registered, the
+ * head never changes. New variants are appended to the tail. This
+ * avoids the need for hash_table_replace (which would orphan the
+ * strdup'd key string and break ownership invariants).
+ */
+static void
+lex_index_by_base(lexicon_t *lex, lex_entry_t *entry)
+{
+    char *base = lex_base_word(entry->ortho);
+    lex_entry_t *head = NULL;
+
+    entry->next_variant = NULL;
+
+    if (hash_table_lookup(lex->base_ht, base, (void **)&head) == 0) {
+	while (head->next_variant != NULL) {
+	    head = head->next_variant;
+	}
+	head->next_variant = entry;
+	/* We didn't take ownership of `base`; it would have been
+	 * a duplicate of the existing key. Free it. */
+	ckd_free(base);
+    } else {
+	/* First variant for this base word. The hash table now owns
+	 * `base` as its key; do not free it here. lexicon_free()
+	 * releases it when iterating base_ht. */
+	hash_table_enter(lex->base_ht, base, (void *)entry);
+    }
 }
 
 lex_entry_t *lexicon_append_entry(lexicon_t *lex)
@@ -214,6 +281,7 @@ lexicon_t *lexicon_read(lexicon_t *prior_lex,
 	}
 	
 	hash_table_enter(lex->ht, next_entry->ortho, (void *)next_entry);
+	lex_index_by_base(lex, next_entry);
 	++wid;	/* only happens should everything be successful */
     }
 
@@ -236,11 +304,49 @@ lex_entry_t *lexicon_lookup(lexicon_t *lex, char *ortho)
     return NULL;
 }
 
+lex_entry_t *
+lexicon_lookup_variants(lexicon_t *lex, const char *base_word)
+{
+    lex_entry_t *head = NULL;
+
+    if (lex == NULL || lex->base_ht == NULL || base_word == NULL) {
+	return NULL;
+    }
+    if (hash_table_lookup(lex->base_ht, base_word, (void **)&head) == 0) {
+	return head;
+    }
+    return NULL;
+}
+
+const char *
+lex_entry_ortho(const lex_entry_t *e)
+{
+    return e ? e->ortho : NULL;
+}
+
+lex_entry_t *
+lex_entry_next_variant(const lex_entry_t *e)
+{
+    return e ? e->next_variant : NULL;
+}
 
 void lexicon_free(lexicon_t *lexicon)
 {
     hash_iter_t *itor;
-    
+
+    if (lexicon == NULL) return;
+
+    /* Free the strdup'd base keys stored in base_ht. The values point
+     * to entries already owned by the main ht; do not free them here. */
+    if (lexicon->base_ht) {
+	for (itor = hash_table_iter(lexicon->base_ht);
+		 itor; itor = hash_table_iter_next(itor)) {
+	    ckd_free((void *)hash_entry_key(itor->ent));
+	}
+	hash_table_free(lexicon->base_ht);
+	lexicon->base_ht = NULL;
+    }
+
     for (itor = hash_table_iter(lexicon->ht);
              itor; itor = hash_table_iter_next(itor)) {
         lex_entry_t *entry = hash_entry_val(itor->ent);

--- a/src/libs/libcommon/phone_graph.c
+++ b/src/libs/libcommon/phone_graph.c
@@ -1,0 +1,337 @@
+/**
+ * @file phone_graph.c
+ * @brief Implementation of the multi-pron-capable phone graph builder.
+ *
+ * See phone_graph.h for the data structure and the contract.
+ */
+
+#include <s3/phone_graph.h>
+#include <s3/s3.h>
+#include <sphinxbase/ckd_alloc.h>
+#include <sphinxbase/err.h>
+
+#include <stdio.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* allocation                                                         */
+/* ------------------------------------------------------------------ */
+
+phone_graph_t *
+phone_graph_alloc(uint32 n)
+{
+    phone_graph_t *g = ckd_calloc(1, sizeof(phone_graph_t));
+    g->n = n;
+    if (n == 0) {
+	return g;
+    }
+    g->phone     = ckd_calloc(n, sizeof(acmod_id_t));
+    g->btw_mark  = ckd_calloc(n, sizeof(char));
+    g->n_next    = ckd_calloc(n, sizeof(uint32));
+    g->next_idx  = ckd_calloc(n, sizeof(uint32 *));
+    g->n_prior   = ckd_calloc(n, sizeof(uint32));
+    g->prior_idx = ckd_calloc(n, sizeof(uint32 *));
+    return g;
+}
+
+void
+phone_graph_free(phone_graph_t *g)
+{
+    uint32 i;
+
+    if (g == NULL) return;
+
+    if (g->next_idx) {
+	for (i = 0; i < g->n; i++) {
+	    if (g->next_idx[i]) ckd_free(g->next_idx[i]);
+	}
+	ckd_free(g->next_idx);
+    }
+    if (g->prior_idx) {
+	for (i = 0; i < g->n; i++) {
+	    if (g->prior_idx[i]) ckd_free(g->prior_idx[i]);
+	}
+	ckd_free(g->prior_idx);
+    }
+    if (g->n_next)   ckd_free(g->n_next);
+    if (g->n_prior)  ckd_free(g->n_prior);
+    if (g->phone)    ckd_free(g->phone);
+    if (g->btw_mark) ckd_free(g->btw_mark);
+
+    ckd_free(g);
+}
+
+/* ------------------------------------------------------------------ */
+/* construction helpers                                               */
+/* ------------------------------------------------------------------ */
+
+/* Set a slot's successor list to a single index (the most common
+ * "linear" case). */
+static void
+set_next_one(phone_graph_t *g, uint32 i, uint32 succ)
+{
+    g->n_next[i] = 1;
+    g->next_idx[i] = ckd_calloc(1, sizeof(uint32));
+    g->next_idx[i][0] = succ;
+}
+
+/* Set a slot's predecessor list to a single index. */
+static void
+set_prior_one(phone_graph_t *g, uint32 i, uint32 pred)
+{
+    g->n_prior[i] = 1;
+    g->prior_idx[i] = ckd_calloc(1, sizeof(uint32));
+    g->prior_idx[i][0] = pred;
+}
+
+/* Set a slot's successor list to a freshly-allocated array of
+ * `n` indices, copied from `idxs`. */
+static void
+set_next_many(phone_graph_t *g, uint32 i, const uint32 *idxs, uint32 n)
+{
+    g->n_next[i] = n;
+    if (n == 0) {
+	g->next_idx[i] = NULL;
+	return;
+    }
+    g->next_idx[i] = ckd_calloc(n, sizeof(uint32));
+    memcpy(g->next_idx[i], idxs, n * sizeof(uint32));
+}
+
+/* Set a slot's predecessor list to a freshly-allocated array of
+ * `n` indices, copied from `idxs`. */
+static void
+set_prior_many(phone_graph_t *g, uint32 i, const uint32 *idxs, uint32 n)
+{
+    g->n_prior[i] = n;
+    if (n == 0) {
+	g->prior_idx[i] = NULL;
+	return;
+    }
+    g->prior_idx[i] = ckd_calloc(n, sizeof(uint32));
+    memcpy(g->prior_idx[i], idxs, n * sizeof(uint32));
+}
+
+/* ------------------------------------------------------------------ */
+/* mk_phone_graph                                                     */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Per-word expansion plan. For each word in the transcript we record
+ * the list of variants we'll include (1 if !multipron, else all from
+ * the base-word index) and where each variant's phone slots sit in
+ * the final flat `phone[]` array.
+ */
+typedef struct word_plan_s {
+    uint32 n_variants;
+    lex_entry_t **variant;     /* [n_variants] */
+    uint32 *first_slot;        /* [n_variants] starting index in phone[] */
+    uint32 *last_slot;         /* [n_variants] last index in phone[] */
+} word_plan_t;
+
+static void
+word_plan_free_all(word_plan_t *plan, uint32 n_word)
+{
+    uint32 i;
+    if (!plan) return;
+    for (i = 0; i < n_word; i++) {
+	if (plan[i].variant)    ckd_free(plan[i].variant);
+	if (plan[i].first_slot) ckd_free(plan[i].first_slot);
+	if (plan[i].last_slot)  ckd_free(plan[i].last_slot);
+    }
+    ckd_free(plan);
+}
+
+phone_graph_t *
+mk_phone_graph(char **word,
+               uint32 n_word,
+               lexicon_t *lex,
+               int multipron)
+{
+    word_plan_t *plan;
+    uint32 i, v, p;
+    uint32 total_slots;
+    phone_graph_t *g;
+    /* word_active[i] is false for words we drop entirely (phone_cnt == 0
+     * for every variant); pass 3 uses this to splice the predecessor
+     * past the dropped word, matching mk_phone_list's behavior of
+     * silently skipping silent dict entries. */
+    char *word_active;
+
+    if (n_word == 0) {
+	E_WARN("Word sequence is empty\n");
+	return NULL;
+    }
+
+    /* Pass 1: gather the variants for each word and count total slots. */
+    plan = ckd_calloc(n_word, sizeof(word_plan_t));
+    word_active = ckd_calloc(n_word, sizeof(char));
+    total_slots = 0;
+
+    for (i = 0; i < n_word; i++) {
+	lex_entry_t *chain_head = NULL;
+	lex_entry_t *single = NULL;
+	uint32 n_var = 0;
+
+	if (multipron) {
+	    chain_head = lexicon_lookup_variants(lex, word[i]);
+	    if (chain_head != NULL) {
+		lex_entry_t *e;
+		for (e = chain_head; e; e = lex_entry_next_variant(e)) {
+		    ++n_var;
+		}
+	    }
+	}
+	if (n_var == 0) {
+	    /* Either !multipron, or multipron with a disambiguated
+	     * transcript token like "reading(2)" that isn't a base
+	     * word: try the direct ortho lookup. */
+	    single = lexicon_lookup(lex, word[i]);
+	    n_var = (single != NULL) ? 1 : 0;
+	}
+	if (n_var == 0) {
+	    E_WARN("Unable to look up word '%s' in the dictionary\n", word[i]);
+	    word_plan_free_all(plan, n_word);
+	    ckd_free(word_active);
+	    return NULL;
+	}
+
+	plan[i].n_variants = n_var;
+	plan[i].variant    = ckd_calloc(n_var, sizeof(lex_entry_t *));
+	plan[i].first_slot = ckd_calloc(n_var, sizeof(uint32));
+	plan[i].last_slot  = ckd_calloc(n_var, sizeof(uint32));
+
+	if (chain_head != NULL) {
+	    lex_entry_t *e;
+	    v = 0;
+	    for (e = chain_head; e; e = lex_entry_next_variant(e), v++) {
+		plan[i].variant[v] = e;
+	    }
+	} else {
+	    plan[i].variant[0] = single;
+	}
+
+	/* Each variant contributes phone_cnt slots. Filter out
+	 * 0-phone variants (collapse them out of the plan); if every
+	 * variant has 0 phones, drop the word entirely to mirror the
+	 * historical mk_phone_list behavior. */
+	{
+	    uint32 kept = 0;
+	    lex_entry_t **kept_variants = ckd_calloc(n_var, sizeof(lex_entry_t *));
+	    uint32 *kept_first = ckd_calloc(n_var, sizeof(uint32));
+	    uint32 *kept_last  = ckd_calloc(n_var, sizeof(uint32));
+	    for (v = 0; v < n_var; v++) {
+		uint32 m = plan[i].variant[v]->phone_cnt;
+		if (m == 0) continue;
+		kept_variants[kept] = plan[i].variant[v];
+		kept_first[kept] = total_slots;
+		kept_last[kept]  = total_slots + m - 1;
+		total_slots += m;
+		++kept;
+	    }
+	    ckd_free(plan[i].variant);
+	    ckd_free(plan[i].first_slot);
+	    ckd_free(plan[i].last_slot);
+	    plan[i].variant    = kept_variants;
+	    plan[i].first_slot = kept_first;
+	    plan[i].last_slot  = kept_last;
+	    plan[i].n_variants = kept;
+	    word_active[i] = (kept > 0) ? 1 : 0;
+	}
+    }
+
+    /* Pass 2: allocate the graph and fill in phone[] + btw_mark[]
+     * along with intra-variant linear adjacencies. */
+    g = phone_graph_alloc(total_slots);
+
+    for (i = 0; i < n_word; i++) {
+	for (v = 0; v < plan[i].n_variants; v++) {
+	    lex_entry_t *e = plan[i].variant[v];
+	    uint32 m = e->phone_cnt;
+	    if (m == 0) continue;
+	    for (p = 0; p < m; p++) {
+		uint32 slot = plan[i].first_slot[v] + p;
+		g->phone[slot] = e->ci_acmod_id[p];
+		/* btw_mark is set only on the last phone of each
+		 * variant (one boundary per variant). */
+		g->btw_mark[slot] = (p == m - 1) ? 1 : 0;
+		if (p < m - 1) {
+		    set_next_one(g, slot, slot + 1);
+		}
+		if (p > 0) {
+		    set_prior_one(g, slot, slot - 1);
+		}
+	    }
+	}
+    }
+
+    /* Pass 3: cross-word edges. The last phone of every variant of
+     * word i connects forward to the first phone of every variant of
+     * the next active word; inactive (0-phone) words are spliced
+     * out. For single-pron neighbors this is exactly the linear
+     * "last(i) -> first(i+1)" edge.
+     *
+     * set_next_many / set_prior_many copy from the source array, so
+     * we pass plan[*].first_slot / plan[*].last_slot directly; no
+     * staging buffer needed. */
+    {
+	uint32 next_active;
+
+	for (i = 0; i < n_word; i++) {
+	    if (!word_active[i]) continue;
+	    for (next_active = i + 1;
+		 next_active < n_word && !word_active[next_active];
+		 next_active++) { /* skip */ }
+	    if (next_active >= n_word) continue;
+
+	    {
+		uint32 nx = plan[next_active].n_variants;
+		uint32 cur = plan[i].n_variants;
+
+		for (v = 0; v < cur; v++) {
+		    set_next_many(g, plan[i].last_slot[v],
+				  plan[next_active].first_slot, nx);
+		}
+		for (v = 0; v < nx; v++) {
+		    set_prior_many(g, plan[next_active].first_slot[v],
+				   plan[i].last_slot, cur);
+		}
+	    }
+	}
+    }
+
+    ckd_free(word_active);
+    word_plan_free_all(plan, n_word);
+    return g;
+}
+
+/* ------------------------------------------------------------------ */
+/* diagnostics                                                        */
+/* ------------------------------------------------------------------ */
+
+void
+phone_graph_print(const phone_graph_t *g, acmod_set_t *acmod_set)
+{
+    uint32 i, j;
+
+    if (!g) {
+	printf("(null phone_graph_t)\n");
+	return;
+    }
+
+    printf("phone_graph_t n=%u\n", g->n);
+    for (i = 0; i < g->n; i++) {
+	printf("  [%3u] %-10s btw=%d next={",
+	       i,
+	       acmod_set ? acmod_set_id2name(acmod_set, g->phone[i]) : "?",
+	       g->btw_mark[i] ? 1 : 0);
+	for (j = 0; j < g->n_next[i]; j++) {
+	    printf("%s%u", (j ? "," : ""), g->next_idx[i][j]);
+	}
+	printf("} prior={");
+	for (j = 0; j < g->n_prior[i]; j++) {
+	    printf("%s%u", (j ? "," : ""), g->prior_idx[i][j]);
+	}
+	printf("}\n");
+    }
+}

--- a/src/libs/libcommon/phone_graph_triphone.c
+++ b/src/libs/libcommon/phone_graph_triphone.c
@@ -1,0 +1,402 @@
+/**
+ * @file phone_graph_triphone.c
+ * @brief Context-split + triphone resolution on a phone_graph_t.
+ *
+ * Two operations live here:
+ *
+ *   phone_graph_split_contexts(in) -> out
+ *     Build a new graph where every slot has at most one distinct
+ *     CI-phone predecessor. Slots whose predecessors carry multiple
+ *     CI phones are duplicated, one copy per distinct predecessor
+ *     CI phone, and the predecessor edges are partitioned. All copies
+ *     of a slot share the same outgoing-edge set, with each outgoing
+ *     edge possibly retargeted via the same split rule applied to the
+ *     successor.
+ *
+ *   cvt2triphone_graph(graph, acmod_set) -> int
+ *     Walks an already-unambiguous-context graph and replaces each
+ *     slot's CI `phone` with its triphone acmod_id, using the same
+ *     fallbacks (word-position back-off, filler handling) as
+ *     cvt2triphone() in the linear path.
+ *
+ * The contract is that callers run split first and cvt2triphone_graph
+ * second; both are skipped automatically when there are no
+ * multi-pron branches in the input.
+ */
+
+#include <s3/phone_graph.h>
+#include <s3/acmod_set.h>
+#include <s3/s3.h>
+#include <sphinxbase/ckd_alloc.h>
+#include <sphinxbase/err.h>
+
+#include <assert.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* phone_graph_split_contexts                                         */
+/* ------------------------------------------------------------------ */
+
+/* Per-old-slot split metadata. */
+typedef struct split_info_s {
+    uint32     n_copies;     /* >=1; equals n distinct CI predecessor phones */
+    uint32     first_new;    /* offset in the new graph */
+    acmod_id_t *group_ci;    /* [n_copies] distinct CI phones, in order */
+} split_info_t;
+
+/* Classify every old slot: how many copies, which CI phone each copy
+ * is for. */
+static split_info_t *
+classify_slots(const phone_graph_t *in, uint32 *total_new)
+{
+    split_info_t *info;
+    acmod_id_t *distinct;
+    acmod_id_t ci;
+    uint32 i, u, v;
+    uint32 n_distinct;
+    uint32 running = 0;
+    int found;
+
+    info = ckd_calloc(in->n, sizeof(split_info_t));
+
+    for (i = 0; i < in->n; i++) {
+	if (in->n_prior[i] <= 1) {
+	    info[i].n_copies = 1;
+	    info[i].group_ci = ckd_calloc(1, sizeof(acmod_id_t));
+	    info[i].group_ci[0] = (in->n_prior[i] == 1)
+				       ? in->phone[in->prior_idx[i][0]]
+				       : 0;  /* unused for n_copies == 1 */
+	    info[i].first_new = running;
+	    running += 1;
+	    continue;
+	}
+	/* Collect distinct predecessor CI phones, preserving the
+	 * order of first occurrence (deterministic for parity). */
+	distinct = ckd_calloc(in->n_prior[i], sizeof(acmod_id_t));
+	n_distinct = 0;
+	for (u = 0; u < in->n_prior[i]; u++) {
+	    ci = in->phone[in->prior_idx[i][u]];
+	    found = 0;
+	    for (v = 0; v < n_distinct; v++) {
+		if (distinct[v] == ci) { found = 1; break; }
+	    }
+	    if (!found) distinct[n_distinct++] = ci;
+	}
+	info[i].n_copies = n_distinct;
+	info[i].group_ci = distinct;     /* hand over ownership */
+	info[i].first_new = running;
+	running += n_distinct;
+    }
+
+    *total_new = running;
+    return info;
+}
+
+static void
+free_split_info(split_info_t *info, uint32 n)
+{
+    uint32 i;
+    if (!info) return;
+    for (i = 0; i < n; i++) {
+	if (info[i].group_ci) ckd_free(info[i].group_ci);
+    }
+    ckd_free(info);
+}
+
+/* Find which copy of slot `c` corresponds to predecessor CI phone
+ * `pred_ci`. */
+static uint32
+copy_for_predecessor_ci(const split_info_t *info, uint32 c, acmod_id_t pred_ci)
+{
+    uint32 g;
+    if (info[c].n_copies == 1) {
+	return info[c].first_new;
+    }
+    for (g = 0; g < info[c].n_copies; g++) {
+	if (info[c].group_ci[g] == pred_ci) {
+	    return info[c].first_new + g;
+	}
+    }
+    assert(0 && "copy_for_predecessor_ci: predecessor CI not found");
+    return 0;
+}
+
+phone_graph_t *
+phone_graph_split_contexts(const phone_graph_t *in)
+{
+    phone_graph_t *out;
+    split_info_t *info;
+    acmod_id_t pred_ci;
+    uint32 *cursor_next = NULL;
+    uint32 *cursor_prior = NULL;
+    uint32 i, u, g, total_new;
+    uint32 ns, p, pg, c_target, p_source, n;
+    int any_split;
+
+    if (!in) return NULL;
+
+    info = classify_slots(in, &total_new);
+
+    /* Fast path: no slot needs splitting. Make a structural copy of
+     * the input so caller-side semantics stay uniform (caller frees
+     * both graphs). */
+    any_split = 0;
+    for (i = 0; i < in->n; i++) {
+	if (info[i].n_copies > 1) { any_split = 1; break; }
+    }
+    if (!any_split) {
+	out = phone_graph_alloc(in->n);
+	for (i = 0; i < in->n; i++) {
+	    out->phone[i]    = in->phone[i];
+	    out->btw_mark[i] = in->btw_mark[i];
+	    out->n_next[i]   = in->n_next[i];
+	    out->n_prior[i]  = in->n_prior[i];
+	    if (in->n_next[i] > 0) {
+		out->next_idx[i] = ckd_calloc(in->n_next[i], sizeof(uint32));
+		memcpy(out->next_idx[i], in->next_idx[i],
+		       in->n_next[i] * sizeof(uint32));
+	    }
+	    if (in->n_prior[i] > 0) {
+		out->prior_idx[i] = ckd_calloc(in->n_prior[i], sizeof(uint32));
+		memcpy(out->prior_idx[i], in->prior_idx[i],
+		       in->n_prior[i] * sizeof(uint32));
+	    }
+	}
+	free_split_info(info, in->n);
+	return out;
+    }
+
+    out = phone_graph_alloc(total_new);
+
+    /* Fill phone[] and btw_mark[] for every copy. */
+    for (i = 0; i < in->n; i++) {
+	for (g = 0; g < info[i].n_copies; g++) {
+	    ns = info[i].first_new + g;
+	    out->phone[ns]    = in->phone[i];
+	    out->btw_mark[ns] = in->btw_mark[i];
+	}
+    }
+
+    /*
+     * Build adjacencies in 3 passes (the count -> allocate -> fill
+     * pattern state_seq.c also uses) to avoid per-edge realloc:
+     *
+     *   1. count: derive every NEW (p_source -> c_target) edge from
+     *      every OLD (p -> c) edge and bump out->n_next[p_source] /
+     *      out->n_prior[c_target].
+     *   2. allocate: per new slot, ckd_calloc exact-sized
+     *      next_idx[] / prior_idx[].
+     *   3. fill: walk OLD edges again, append at the per-slot cursor.
+     *
+     * The mapping from OLD to NEW edges:
+     *   - c_target = copy_for_predecessor_ci(c, phone[p])  (the one
+     *     copy of c whose partition this CI predecessor falls into)
+     *   - every copy of p contributes an outgoing edge into c_target
+     *     (all copies of p share the same outgoing edge set).
+     */
+
+    /* Pass 1: count. */
+    for (i = 0; i < in->n; i++) {
+	for (u = 0; u < in->n_prior[i]; u++) {
+	    p = in->prior_idx[i][u];
+	    pred_ci = in->phone[p];
+	    c_target = copy_for_predecessor_ci(info, i, pred_ci);
+	    n = info[p].n_copies;
+	    out->n_prior[c_target] += n;
+	    for (pg = 0; pg < n; pg++) {
+		++out->n_next[info[p].first_new + pg];
+	    }
+	}
+    }
+
+    /* Pass 2: allocate exact-sized adjacency arrays. */
+    for (ns = 0; ns < total_new; ns++) {
+	if (out->n_next[ns] > 0) {
+	    out->next_idx[ns] = ckd_calloc(out->n_next[ns], sizeof(uint32));
+	}
+	if (out->n_prior[ns] > 0) {
+	    out->prior_idx[ns] = ckd_calloc(out->n_prior[ns], sizeof(uint32));
+	}
+    }
+
+    /* Pass 3: fill. cursor_next[s] / cursor_prior[s] track the next
+     * write position inside out->next_idx[s] / out->prior_idx[s]. */
+    cursor_next  = ckd_calloc(total_new, sizeof(uint32));
+    cursor_prior = ckd_calloc(total_new, sizeof(uint32));
+    for (i = 0; i < in->n; i++) {
+	for (u = 0; u < in->n_prior[i]; u++) {
+	    p = in->prior_idx[i][u];
+	    pred_ci = in->phone[p];
+	    c_target = copy_for_predecessor_ci(info, i, pred_ci);
+	    for (pg = 0; pg < info[p].n_copies; pg++) {
+		p_source = info[p].first_new + pg;
+		out->next_idx[p_source][cursor_next[p_source]++] = c_target;
+		out->prior_idx[c_target][cursor_prior[c_target]++] = p_source;
+	    }
+	}
+    }
+    ckd_free(cursor_next);
+    ckd_free(cursor_prior);
+
+    free_split_info(info, in->n);
+    return out;
+}
+
+/* ------------------------------------------------------------------ */
+/* cvt2triphone_graph                                                 */
+/* ------------------------------------------------------------------ */
+
+/* Re-implementation of cvt2triphone.c's btw_posn() (which isn't
+ * declared in any header). Same semantics: advance the word-position
+ * state given the boundary marker of the current phone. */
+static word_posn_t
+graph_btw_posn(char btw_mark, word_posn_t posn)
+{
+    if (btw_mark) {
+	if (posn == WORD_POSN_INTERNAL || posn == WORD_POSN_BEGIN) {
+	    return WORD_POSN_END;
+	}
+	if (posn == WORD_POSN_END) return WORD_POSN_SINGLE;
+	if (posn == WORD_POSN_SINGLE) return WORD_POSN_SINGLE;
+	E_FATAL("Unhandled word position\n");
+    } else {
+	if (posn == WORD_POSN_BEGIN) return WORD_POSN_INTERNAL;
+	if (posn == WORD_POSN_END || posn == WORD_POSN_SINGLE) {
+	    return WORD_POSN_BEGIN;
+	}
+	if (posn == WORD_POSN_INTERNAL) return WORD_POSN_INTERNAL;
+	E_FATAL("Unhandled word position\n");
+    }
+    return posn;
+}
+
+int
+cvt2triphone_graph(phone_graph_t *graph, acmod_set_t *acmod_set)
+{
+    uint32 i;
+    acmod_id_t sil;
+    acmod_id_t *new_phone;
+    word_posn_t *posn_track;
+
+    if (!graph || !acmod_set) return S3_ERROR;
+    if (graph->n == 0) return S3_SUCCESS;
+
+    if (acmod_set_n_multi(acmod_set) == 0) {
+	/* No triphones in the model; nothing to do. Matches
+	 * cvt2triphone()'s early-out. */
+	return S3_SUCCESS;
+    }
+
+    sil = acmod_set_name2id(acmod_set, "SIL");
+
+    /* We compute the new triphone id for each slot from the CI ids in
+     * `graph->phone[]`, but we MUST NOT overwrite slot i's phone[]
+     * before we read it as a left/right context for its neighbors.
+     * Use a scratch buffer for the new ids and assign at the end. */
+    new_phone = ckd_calloc(graph->n, sizeof(acmod_id_t));
+
+    /* Per-slot word position. Each slot inherits from a predecessor's
+     * "outgoing" position state, with the boundary marker advancing
+     * it. Since the graph may have fan-in (all incoming arcs with the
+     * same CI predecessor, by construction of split_contexts), every
+     * predecessor produces the same word-position state at slot i —
+     * so we can compute posn per slot in topological order. We rely
+     * on the slot ordering produced by mk_phone_graph (per-variant
+     * sequential, words in transcript order) which is a valid topo
+     * order. */
+    posn_track = ckd_calloc(graph->n, sizeof(word_posn_t));
+
+    for (i = 0; i < graph->n; i++) {
+	word_posn_t in_posn;
+	acmod_id_t b, l, r;
+	acmod_id_t tri_id;
+	int found;
+	int j;
+
+	b = graph->phone[i];
+
+	/* Determine incoming word-position state. For slot 0 (no
+	 * predecessor), seed with WORD_POSN_END as the linear
+	 * cvt2triphone does. Otherwise inherit from any predecessor;
+	 * by post-split construction all predecessors agree on the
+	 * outgoing posn state. */
+	if (graph->n_prior[i] == 0) {
+	    in_posn = WORD_POSN_END;
+	} else {
+	    in_posn = posn_track[graph->prior_idx[i][0]];
+	}
+
+	posn_track[i] = graph_btw_posn(graph->btw_mark[i], in_posn);
+
+	/* Left context: the CI phone of any predecessor (after split
+	 * they all agree). For slot 0 (no predecessor), use SIL. */
+	if (graph->n_prior[i] == 0) {
+	    l = sil;
+	} else {
+	    acmod_id_t pred_phone = graph->phone[graph->prior_idx[i][0]];
+	    if (acmod_set_has_attrib(acmod_set, pred_phone, "filler")) {
+		l = sil;
+	    } else {
+		l = acmod_set_base_phone(acmod_set, pred_phone);
+	    }
+	}
+
+	/* Right context: CI phone of any successor. The linear path
+	 * uses phone[i+1]. For a graph we don't currently split on
+	 * the SUCCESSOR side, so when n_next > 1 with varying CI
+	 * phones we pick the first one (documented approximation). */
+	if (graph->n_next[i] == 0) {
+	    r = sil;
+	} else if (graph->n_next[i] == 1) {
+	    acmod_id_t succ_phone = graph->phone[graph->next_idx[i][0]];
+	    if (acmod_set_has_attrib(acmod_set, succ_phone, "filler")) {
+		r = sil;
+	    } else {
+		r = acmod_set_base_phone(acmod_set, succ_phone);
+	    }
+	} else {
+	    acmod_id_t succ_phone = graph->phone[graph->next_idx[i][0]];
+	    if (acmod_set_has_attrib(acmod_set, succ_phone, "filler")) {
+		r = sil;
+	    } else {
+		r = acmod_set_base_phone(acmod_set, succ_phone);
+	    }
+	}
+
+	/* If the center phone is a filler, leave the CI id alone
+	 * (matches the linear path). */
+	if (acmod_set_has_attrib(acmod_set, b, "filler")) {
+	    new_phone[i] = b;
+	    continue;
+	}
+
+	tri_id = acmod_set_tri2id(acmod_set, b, l, r, posn_track[i]);
+	if (tri_id != NO_ACMOD) {
+	    new_phone[i] = tri_id;
+	    continue;
+	}
+	/* Back off across word positions, same as the linear path. */
+	found = 0;
+	for (j = 0; j < N_WORD_POSN; ++j) {
+	    tri_id = acmod_set_tri2id(acmod_set, b, l, r, j);
+	    if (tri_id != NO_ACMOD) {
+		new_phone[i] = tri_id;
+		found = 1;
+		break;
+	    }
+	}
+	if (!found) {
+	    /* Leave as CI id; the linear path does the same with an
+	     * (off-by-default) E_WARN. */
+	    new_phone[i] = b;
+	}
+    }
+
+    for (i = 0; i < graph->n; i++) {
+	graph->phone[i] = new_phone[i];
+    }
+
+    ckd_free(new_phone);
+    ckd_free(posn_track);
+    return S3_SUCCESS;
+}

--- a/src/libs/libcommon/state_seq.c
+++ b/src/libs/libcommon/state_seq.c
@@ -48,7 +48,7 @@
 
 
 #include <s3/state_seq.h>
-
+
 #include <s3/remap.h>
 #include <sphinxbase/cmd_ln.h>
 #include <sphinxbase/ckd_alloc.h>
@@ -56,6 +56,8 @@
 #include <s3/model_def_io.h>
 #include <string.h>
 #include <assert.h>
+
+#include "state_seq_internal.h"
 
 /*********************************************************************
  *
@@ -196,13 +198,13 @@ state_seq_print(state_t *state,
     }
 }
 
-static void
-set_next_state(state_t *state,
-	       uint32 s,
-	       uint32 *n_next,
-	       uint32 *next_state,
-	       float32 *next_tprob,
-	       uint32 *n)
+void
+state_seq_set_next(state_t *state,
+		   uint32 s,
+		   const uint32 *n_next,
+		   uint32 *next_state,
+		   float32 *next_tprob,
+		   uint32 *n)
 {
     uint32 i = *n;
 
@@ -212,19 +214,21 @@ set_next_state(state_t *state,
 	state[s].next_tprob = &next_tprob[i];
 	state[s].next_state = &next_state[i];
     }
-    else
+    else {
 	state[s].next_tprob = NULL;
+	state[s].next_state = NULL;
+    }
 
     *n = i + n_next[s];
 }
 
-static uint32
-set_prior_state(state_t *state,
-		uint32 s,
-		uint32 *n_prior,
-		uint32 *prior_state,
-		float32 *prior_tprob,
-		uint32 *p)
+void
+state_seq_set_prior(state_t *state,
+		    uint32 s,
+		    const uint32 *n_prior,
+		    uint32 *prior_state,
+		    float32 *prior_tprob,
+		    uint32 *p)
 {
     uint32 i = *p;
 
@@ -234,12 +238,12 @@ set_prior_state(state_t *state,
 	state[s].prior_state = &prior_state[i];
 	state[s].prior_tprob = &prior_tprob[i];
     }
-    else
+    else {
 	state[s].prior_tprob = NULL;
+	state[s].prior_state = NULL;
+    }
 
     *p = i + n_prior[s];
-
-    return S3_SUCCESS;
 }
 
 static void
@@ -569,10 +573,10 @@ state_seq_make(uint32 *n_state,
 	    state[k].ci_cb = mdef->cb[t_ci_state];
 	    
 	    /* Set next state list and transition prob list (for forward eval) */
-	    set_next_state(state, k, n_next, next_state, next_tprob, &n);
+	    state_seq_set_next(state, k, n_next, next_state, next_tprob, &n);
 
 	    /* Set prior state list and transition prob list (for backward eval) */
-	    set_prior_state(state, k, n_prior, prior_state, prior_tprob, &p);
+	    state_seq_set_prior(state, k, n_prior, prior_state, prior_tprob, &p);
 
 	    /* Update the out-degree so far */
 	    if (state[k].n_next > max_n_next)
@@ -607,8 +611,8 @@ state_seq_make(uint32 *n_state,
 	state[k].m_state = j;
 	state[k].phn = phn;
 
-	set_prior_state(state, k, n_prior, prior_state, prior_tprob, &p);
-	set_next_state(state, k, n_next, next_state, next_tprob, &n);
+	state_seq_set_prior(state, k, n_prior, prior_state, prior_tprob, &p);
+	state_seq_set_next(state, k, n_next, next_state, next_tprob, &n);
 
 	++k;
     }

--- a/src/libs/libcommon/state_seq_graph.c
+++ b/src/libs/libcommon/state_seq_graph.c
@@ -1,0 +1,330 @@
+/**
+ * @file state_seq_graph.c
+ * @brief Graph-aware utterance HMM builder. See state_seq_graph.h.
+ *
+ * Architecture mirrors state_seq.c's three-pass design:
+ *
+ *   1. Counter: compute n_next[s] and n_prior[s] for every state s.
+ *      Cross-phone arcs are read from the phone graph's adjacency
+ *      lists instead of assumed to be "i -> i+1".
+ *   2. Allocate the packed next_state[] / prior_state[] arrays.
+ *   3. Writer: fill the packed arrays. Crucially, the write order
+ *      must match the read order of the assembly pass (state index 0,
+ *      1, 2, ..., n_s - 1), since each set_next_state / set_prior_state
+ *      call slices off the next n_next[k] / n_prior[k] entries.
+ *   4. Assembly: build the state_t array using state_seq_set_next /
+ *      state_seq_set_prior, the same helpers state_seq.c uses for
+ *      the linear path.
+ *
+ * Each phone slot in the graph occupies a contiguous block of states:
+ *   state_offset[i] = sum over earlier slots of n_state(phone[j])
+ *
+ * For a linear graph (single-pron), the resulting state_t array is
+ * bit-identical to state_seq_make()'s on the equivalent phone[] list:
+ * outgoing arcs for non-emit exits have count 1 with tprob 1.0
+ * targeting the first state of the next phone — same as i+1.
+ *
+ * For wide graphs, the non-emit exit of slot i fans out to the first
+ * states of all graph successors, with uniform 1/n_next[i] tprob per
+ * arc.
+ */
+
+#include <s3/state_seq_graph.h>
+
+#include <s3/model_def_io.h>
+#include <s3/remap.h>
+#include <s3/s3.h>
+#include <s3/state_seq.h>
+#include <sphinxbase/ckd_alloc.h>
+#include <sphinxbase/err.h>
+
+#include <assert.h>
+#include <string.h>
+
+#include "state_seq_internal.h"
+
+/* ----- Counter ----- */
+
+static void
+count_arcs(const phone_graph_t *graph,
+           const uint32 *state_offset,
+           const model_def_entry_t *defn,
+           float32 ***all_tmat,
+           uint32 *n_next,
+           uint32 *total_next,
+           uint32 *n_prior,
+           uint32 *total_prior)
+{
+    uint32 tn = 0, tp = 0;
+    uint32 i, j, k;
+
+    for (i = 0; i < graph->n; i++) {
+	uint32 l = state_offset[i];
+	uint32 tmat_id = defn[graph->phone[i]].tmat;
+	uint32 n_ms   = defn[graph->phone[i]].n_state;
+	float32 **mt  = all_tmat[tmat_id];
+
+	/* Intra-phone forward arcs. */
+	for (j = 0; j < n_ms - 1; j++) {
+	    for (k = 0; k < n_ms; k++) {
+		if (mt[j][k] > 0.0f) {
+		    ++tn;
+		    ++n_next[l + j];
+		}
+	    }
+	}
+
+	/* Intra-phone backward arcs. */
+	for (j = 0; j < n_ms; j++) {
+	    for (k = 0; k < n_ms - 1; k++) {
+		if (mt[k][j] > 0.0f) {
+		    ++tp;
+		    ++n_prior[l + j];
+		}
+	    }
+	}
+
+	/* Cross-phone arcs: the non-emit exit fans out to the first
+	 * states of every graph successor (and the first state has
+	 * one incoming arc from every graph predecessor's exit). */
+	n_next[l + n_ms - 1] += graph->n_next[i];
+	tn += graph->n_next[i];
+
+	n_prior[l] += graph->n_prior[i];
+	tp += graph->n_prior[i];
+    }
+
+    *total_next = tn;
+    *total_prior = tp;
+}
+
+/* ----- Writer ----- */
+
+static void
+write_arcs(const phone_graph_t *graph,
+           const uint32 *state_offset,
+           const model_def_entry_t *defn,
+           float32 ***all_tmat,
+           uint32 *next_state,
+           float32 *next_tprob,
+           const uint32 *n_next,
+           uint32 total_next,
+           uint32 *prior_state,
+           float32 *prior_tprob,
+           const uint32 *n_prior,
+           uint32 total_prior)
+{
+    uint32 i, j, k, u;
+    uint32 n = 0, p = 0;
+
+    for (i = 0; i < graph->n; i++) {
+	uint32 l = state_offset[i];
+	uint32 tmat_id = defn[graph->phone[i]].tmat;
+	uint32 n_ms   = defn[graph->phone[i]].n_state;
+	float32 **mt  = all_tmat[tmat_id];
+
+	/* Cross-phone incoming arc(s) to first state. Each
+	 * predecessor's outgoing weight to this slot is
+	 * 1 / n_next[predecessor]. */
+	for (u = 0; u < graph->n_prior[i]; u++) {
+	    uint32 pred_slot = graph->prior_idx[i][u];
+	    uint32 pred_n_ms = defn[graph->phone[pred_slot]].n_state;
+	    uint32 pred_exit = state_offset[pred_slot] + pred_n_ms - 1;
+	    float32 weight = 1.0f / (float32) graph->n_next[pred_slot];
+	    prior_tprob[p] = weight;
+	    prior_state[p++] = pred_exit;
+	}
+
+	/* Intra-phone forward arcs from each emit state. */
+	for (j = 0; j < n_ms - 1; j++) {
+	    uint32 n0 = n;
+	    for (k = 0; k < n_ms; k++) {
+		if (mt[j][k] > 0.0f) {
+		    next_tprob[n] = mt[j][k];
+		    next_state[n++] = l + k;
+		}
+	    }
+	    assert(n_next[l + j] == (n - n0));
+	    (void) n0;
+	}
+
+	/* Intra-phone backward arcs to each state. */
+	for (j = 0; j < n_ms; j++) {
+	    for (k = 0; k < n_ms - 1; k++) {
+		if (mt[k][j] > 0.0f) {
+		    prior_tprob[p] = mt[k][j];
+		    prior_state[p++] = l + k;
+		}
+	    }
+	}
+
+	/* Cross-phone outgoing arcs from non-emit exit to each
+	 * graph successor's first state, uniform 1/n_next[i]. */
+	if (graph->n_next[i] > 0) {
+	    float32 weight = 1.0f / (float32) graph->n_next[i];
+	    for (u = 0; u < graph->n_next[i]; u++) {
+		uint32 succ_slot = graph->next_idx[i][u];
+		next_tprob[n] = weight;
+		next_state[n++] = state_offset[succ_slot];
+	    }
+	}
+    }
+
+    assert(n == total_next);
+    assert(p == total_prior);
+    (void) total_next;
+    (void) total_prior;
+}
+
+/* ----- Top-level builder ----- */
+
+state_t *
+state_seq_make_graph(uint32 *n_state,
+                     const phone_graph_t *graph,
+                     model_inventory_t *inv,
+                     model_def_t *mdef)
+{
+    state_t *state = NULL;
+    uint32 *n_prior = NULL;
+    uint32 *n_next = NULL;
+    uint32 *next_state = NULL;
+    float32 *next_tprob = NULL;
+    uint32 *prior_state = NULL;
+    float32 *prior_tprob = NULL;
+    uint32 *state_offset = NULL;
+    map_t *mixw_map = NULL;
+    map_t *cb_map = NULL;
+    uint32 i, j, k;
+    uint32 n_s = 0;
+    uint32 total_next = 0;
+    uint32 total_prior = 0;
+    uint32 n, p;
+    model_def_entry_t *defn = mdef->defn;
+    acmod_set_t *acmod_set = mdef->acmod_set;
+    float32 ***all_tmat = inv->tmat;
+    uint32 n_map;
+
+    if (graph == NULL || graph->n == 0) {
+	return NULL;
+    }
+
+    /* Compute total state count and per-slot state offsets. */
+    state_offset = ckd_calloc(graph->n, sizeof(uint32));
+    for (i = 0; i < graph->n; i++) {
+	state_offset[i] = n_s;
+	n_s += defn[graph->phone[i]].n_state;
+    }
+
+    state    = ckd_calloc(n_s, sizeof(state_t));
+    n_prior  = ckd_calloc(n_s, sizeof(uint32));
+    n_next   = ckd_calloc(n_s, sizeof(uint32));
+
+    mixw_map = remap_init(4 * n_s);
+    cb_map   = remap_init(4 * n_s);
+
+    count_arcs(graph, state_offset, defn, all_tmat,
+               n_next, &total_next,
+               n_prior, &total_prior);
+
+    next_state  = ckd_calloc(total_next,  sizeof(uint32));
+    next_tprob  = ckd_calloc(total_next,  sizeof(float32));
+    prior_state = ckd_calloc(total_prior, sizeof(uint32));
+    prior_tprob = ckd_calloc(total_prior, sizeof(float32));
+
+    write_arcs(graph, state_offset, defn, all_tmat,
+               next_state, next_tprob, n_next, total_next,
+               prior_state, prior_tprob, n_prior, total_prior);
+
+    /* Assemble state_t array, mirroring state_seq.c's per-state
+     * initialization. */
+    n = 0;
+    p = 0;
+    for (i = 0, k = 0; i < graph->n; i++) {
+	acmod_id_t phn = graph->phone[i];
+	acmod_id_t ci_phn = acmod_set_base_phone(acmod_set, phn);
+	uint32 n_ms = defn[phn].n_state;
+	uint32 tmat = defn[phn].tmat;
+	uint32 t_state;
+	uint32 t_ci_state;
+
+	assert(n_ms == defn[ci_phn].n_state);
+
+	for (j = 0; j < n_ms - 1; j++, k++) {
+	    t_state    = defn[phn].state[j];
+	    t_ci_state = defn[ci_phn].state[j];
+
+	    state[k].phn      = phn;
+	    state[k].mixw     = t_state;
+	    state[k].cb       = mdef->cb[t_state];
+	    state[k].ci_mixw  = t_ci_state;
+	    state[k].ci_cb    = mdef->cb[t_ci_state];
+
+	    state_seq_set_next(state, k, n_next,
+			       next_state, next_tprob, &n);
+	    state_seq_set_prior(state, k, n_prior,
+				prior_state, prior_tprob, &p);
+
+	    state[k].tmat    = tmat;
+	    state[k].m_state = j;
+
+	    state[k].l_mixw    = remap(mixw_map, state[k].mixw);
+	    state[k].l_cb      = remap(cb_map,   state[k].cb);
+	    state[k].l_ci_mixw = remap(mixw_map, state[k].ci_mixw);
+	    state[k].l_ci_cb   = remap(cb_map,   state[k].ci_cb);
+	}
+
+	/* Non-emit exit state. */
+	state[k].mixw =
+	    state[k].ci_mixw =
+	    state[k].l_mixw =
+	    state[k].l_ci_mixw = TYING_NO_ID;
+
+	state[k].cb =
+	    state[k].ci_cb =
+	    state[k].l_cb =
+	    state[k].l_ci_cb = TYING_NO_ID;
+
+	state[k].tmat    = tmat;
+	state[k].m_state = j;
+	state[k].phn     = phn;
+
+	state_seq_set_prior(state, k, n_prior,
+			    prior_state, prior_tprob, &p);
+	state_seq_set_next(state, k, n_next,
+			   next_state, next_tprob, &n);
+
+	++k;
+    }
+
+    assert(k == n_s);
+    assert(n == total_next);
+    assert(p == total_prior);
+
+    /* Side effect parity with state_seq_make: refresh the inventory's
+     * mixw_inverse / cb_inverse maps. */
+    if (inv->l_mixw_acc) {
+	ckd_free_3d((void ***) inv->l_mixw_acc);
+	inv->l_mixw_acc = NULL;
+    }
+    if (inv->mixw_inverse) ckd_free((void *) inv->mixw_inverse);
+    inv->mixw_inverse = remap_inverse(mixw_map, &n_map);
+    inv->n_mixw_inverse = n_map;
+
+    if (inv->cb_inverse) ckd_free((void *) inv->cb_inverse);
+    inv->cb_inverse = remap_inverse(cb_map, &n_map);
+    inv->n_cb_inverse = n_map;
+
+    remap_free(mixw_map);
+    remap_free(cb_map);
+
+    ckd_free(n_prior);
+    ckd_free(n_next);
+    ckd_free(state_offset);
+
+    /* next_state/next_tprob/prior_state/prior_tprob are NOT freed;
+     * they're now referenced by state[].next_state / prior_state /
+     * tprob fields. state_seq_free() releases them. */
+
+    *n_state = n_s;
+    return state;
+}

--- a/src/libs/libcommon/state_seq_internal.h
+++ b/src/libs/libcommon/state_seq_internal.h
@@ -1,0 +1,33 @@
+/**
+ * @file state_seq_internal.h
+ * @brief Private helpers shared between state_seq.c and state_seq_graph.c.
+ *
+ * Not for use outside libcommon. The signatures slice the next
+ * n_next[s] / n_prior[s] entries out of the packed next_state[] /
+ * prior_state[] (and matching tprob[]) arrays into state[s] and
+ * advance the running cursor `*n` / `*p`.
+ */
+
+#ifndef STATE_SEQ_INTERNAL_H
+#define STATE_SEQ_INTERNAL_H
+
+#include <s3/state.h>
+#include <sphinxbase/prim_type.h>
+
+void
+state_seq_set_next(state_t *state,
+		   uint32 s,
+		   const uint32 *n_next,
+		   uint32 *next_state,
+		   float32 *next_tprob,
+		   uint32 *n);
+
+void
+state_seq_set_prior(state_t *state,
+		    uint32 s,
+		    const uint32 *n_prior,
+		    uint32 *prior_state,
+		    float32 *prior_tprob,
+		    uint32 *p);
+
+#endif /* STATE_SEQ_INTERNAL_H */

--- a/src/programs/bw/main.c
+++ b/src/programs/bw/main.c
@@ -61,6 +61,7 @@
 #include <s3/model_inventory.h>
 #include <s3/model_def_io.h>
 #include <s3/s3ts2cb_io.h>
+#include <s3/state_seq.h>
 #include <s3/mllr.h>
 #include <s3/mllr_io.h>
 #include <s3/ts2cb.h>
@@ -627,6 +628,7 @@ main_reestimate(model_inventory_t *inv,
 
     uint32 maxuttlen;
     uint32 n_frame_skipped = 0;
+    int multipron_on;
 
     uint32 ckpt_intv = 0;
     uint32 no_retries = 0;
@@ -685,6 +687,11 @@ main_reestimate(model_inventory_t *inv,
     b_beam = cmd_ln_float64("-bbeam");
     spthresh = cmd_ln_float32("-spthresh");
     maxuttlen = cmd_ln_int32("-maxuttlen");
+    /* Hoisted out of the per-utterance loop: the graph builder allocates
+     * the state_t array fresh per call while the linear builder reuses
+     * a static buffer, so we MUST NOT state_seq_free() the linear-path
+     * result. Same flag is queried at the build site and at cleanup. */
+    multipron_on = cmd_ln_int32("-multipron");
 
     /* Begin by skipping over some (possibly zero) # of utterances.
      * Continue to process utterances until there are no more (either EOF
@@ -791,7 +798,11 @@ main_reestimate(model_inventory_t *inv,
         if (timers)
 	    ptmr_start(&timers->upd_timer);
 	/* create a sentence HMM */
-	state_seq = next_utt_states(&n_state, lex, inv, mdef, trans);
+	if (multipron_on) {
+	    state_seq = next_utt_states_graph(&n_state, lex, inv, mdef, trans);
+	} else {
+	    state_seq = next_utt_states(&n_state, lex, inv, mdef, trans);
+	}
 	printf(" %5u", n_state);
 	
 	if (state_seq == NULL) {
@@ -851,6 +862,13 @@ main_reestimate(model_inventory_t *inv,
 
 	if (timers)
 	    ptmr_stop(&timers->upd_timer);
+
+	/* Free only in the multipron case so we don't double-free the
+	 * linear path's static buffer. */
+	if (multipron_on && state_seq != NULL) {
+	    state_seq_free(state_seq, n_state);
+	    state_seq = NULL;
+	}
 
 	if (pdumpfh)
 		fclose(pdumpfh);

--- a/src/programs/bw/next_utt_states.c
+++ b/src/programs/bw/next_utt_states.c
@@ -48,10 +48,13 @@
 #include <s3/lexicon.h>
 #include <s3/model_inventory.h>
 #include <sphinxbase/ckd_alloc.h>
+#include <sphinxbase/err.h>
 #include <s3/mk_phone_list.h>
 #include <s3/cvt2triphone.h>
 
 #include <s3/state_seq.h>
+#include <s3/phone_graph.h>
+#include <s3/state_seq_graph.h>
 
 #include "next_utt_states.h"
 
@@ -108,6 +111,49 @@ state_t *next_utt_states(uint32 *n_state,
     ckd_free(word);
     ckd_free(utterance);
 
+    return state_seq;
+}
+
+state_t *
+next_utt_states_graph(uint32 *n_state,
+		      lexicon_t *lex,
+		      model_inventory_t *inv,
+		      model_def_t *mdef,
+		      char *trans)
+{
+    state_t *state_seq = NULL;
+    phone_graph_t *graph = NULL;
+    phone_graph_t *split = NULL;
+    char **words;
+    char *utterance;
+    uint32 n_word;
+
+    utterance = ckd_salloc(trans);
+    n_word = str2words(utterance, NULL, 0);
+    if (n_word == 0) {
+	E_WARN("Empty utterance: '%s'\n", trans);
+	ckd_free(utterance);
+	return NULL;
+    }
+    words = ckd_calloc(n_word, sizeof(char *));
+    str2words(utterance, words, n_word);
+
+    graph = mk_phone_graph(words, n_word, lex, /*multipron=*/ 1);
+    ckd_free(words);
+    ckd_free(utterance);
+    if (!graph) return NULL;
+
+    split = phone_graph_split_contexts(graph);
+    phone_graph_free(graph);
+    if (!split) return NULL;
+
+    if (cvt2triphone_graph(split, inv->acmod_set) != S3_SUCCESS) {
+	phone_graph_free(split);
+	return NULL;
+    }
+
+    state_seq = state_seq_make_graph(n_state, split, inv, mdef);
+    phone_graph_free(split);
     return state_seq;
 }
 

--- a/src/programs/bw/next_utt_states.h
+++ b/src/programs/bw/next_utt_states.h
@@ -58,6 +58,17 @@ state_t *next_utt_states(uint32 *n_state,
 			 model_def_t *mdef,
 			 char *transcript);
 
+/* Multi-pron variant of next_utt_states. Builds the per-utterance
+ * HMM as a graph with parallel paths for every pronunciation variant
+ * of each word in the transcript. Caller MUST free the returned
+ * state_t* with state_seq_free(); unlike next_utt_states which uses
+ * static buffers, this allocates fresh per call. */
+state_t *next_utt_states_graph(uint32 *n_state,
+			       lexicon_t *lex,
+			       model_inventory_t *inv,
+			       model_def_t *mdef,
+			       char *transcript);
+
 state_t *next_utt_states_mmie(uint32 *n_state,
 			      lexicon_t *lex,
 			      model_inventory_t *inv,

--- a/src/programs/bw/train_cmd_ln.c
+++ b/src/programs/bw/train_cmd_ln.c
@@ -549,6 +549,13 @@ If yo want to do parallel training for N machines. Run N trainers with \n\
 	  ARG_FLOAT32,
 	  "11.5",
 	  "Language model weight" },
+
+	{ "-multipron",
+	  ARG_BOOLEAN,
+	  "no",
+	  "Build per-utterance training HMMs with parallel paths per "
+	  "pronunciation variant; forward-backward sums posteriors "
+	  "across variants. Default no for SphinxTrain parity." },
 	/* end */
 	
 	cepstral_to_feature_command_line_macro(),

--- a/templates/librispeech/etc/sphinx_train.cfg
+++ b/templates/librispeech/etc/sphinx_train.cfg
@@ -204,6 +204,20 @@ $CFG_FORCE_ALIGN_BEAM = 1e-60;
 # 11.force_align. Beam for multipron_align follows $CFG_FORCE_ALIGN_BEAM (else 1e-308).
 $CFG_MULTIPRON = 'yes';
 
+# Enable multi-pronunciation Baum-Welch training. When yes, every bw invocation
+# is passed -multipron yes; bw then builds the per-utterance training HMM as a
+# graph with parallel paths for every dictionary variant of each word, and the
+# forward/backward sums posterior over the variants. When no, the trainer
+# silently picks pronunciation variant [1] for every multi-pron word — the
+# historical SphinxTrain behavior.
+#
+# Independent of $CFG_MULTIPRON above. The two compose well and the recommended
+# setup is to keep both yes: stage 21 produces a transcript where high-confidence
+# tokens already carry an explicit (N) suffix (and so collapse to a single-variant
+# expansion in the graph builder), while the graph builder still branches on the
+# remaining un-disambiguated tokens during BW.
+$CFG_MULTIPRON_TRAINING = 'yes';
+
 # Second CI pass after multipron (stage 22): re-run stage-20 training with supervision
 # from the multipron transcript (GetLists selects it once the file from stage 21 exists).
 # Re-runs flat init and replaces the CI model directory—roughly doubles CI wall time.


### PR DESCRIPTION
# Multi-pronunciation Baum-Welch training

Baum-Welch in SphinxTrain silently uses pronunciation variant `[1]` for every
multi-pron word in the dictionary, so `(2)`/`(3)` entries receive no acoustic
training unless the transcript token already carries an explicit `(N)` suffix.

This branch fixes that in the utterance-HMM construction layer. The forward,
backward, viterbi, and accumulator code paths are unchanged; they already
operate on a general DAG via `state_t.next_state[]` and `prior_state[]`. The
change replaces the implicit linear phone chain produced by `mk_phone_list`
with an explicit `phone_graph_t` carrying parallel paths per pronunciation
variant, then resolves triphone contexts and builds the state sequence over
that graph.

## Commits

1. `Add lexicon base-word variant index` — `lex_entry_t.next_variant` chain
   and a parallel `lexicon_t.base_ht` keyed by the base word (`reading` for
   `reading(2)`). Existing `lexicon_lookup` behavior unchanged.

2. `Add phone_graph_t and graph-aware state-sequence builder` — new
   `mk_phone_graph`, `phone_graph_split_contexts`, `cvt2triphone_graph`, and
   `state_seq_make_graph`. For a single-pron utterance the graph is a strict
   linear chain and the resulting state array is bit-identical to
   `state_seq_make`'s. Renames the two static helpers in `state_seq.c` and
   shares them via a new private `state_seq_internal.h`.

3. `bw: add -multipron flag selecting the graph utterance HMM` — wires a new
   `next_utt_states_graph` into `bw`'s main loop, gated by `-multipron`
   (default `no` for parity). The graph path allocates `state_t` per call and
   is freed with `state_seq_free`; the linear path's static-buffer lifetime
   is unchanged.

4. `Add CFG_MULTIPRON_TRAINING knob to pass -multipron to bw` — new
   `CFG_MULTIPRON_TRAINING` (default `yes`) in `etc/sphinx_train.cfg` and the
   librispeech template, plumbed into every `baum_welch.pl` under
   `01.lda_train`, `02.mllt_train`, `10.falign_ci_hmm`, `20.ci_hmm`,
   `30.cd_hmm_untied`, `50.cd_hmm_tied`, `65.mmie_train`, and `80.mllr_adapt`.

`CFG_MULTIPRON_TRAINING` is independent of `CFG_MULTIPRON` (the stage-21
`sphinx3_align` disambiguation pass). The two compose: tokens already
disambiguated by stage 21 carry an `(N)` suffix and collapse to a
single-variant expansion in the graph builder; un-disambiguated tokens still
branch on every dictionary variant during Baum-Welch.

## Compatibility

- C-side default `-multipron no` preserves prior behavior. Each commit
  compiles standalone.
- Cfg-side default `CFG_MULTIPRON_TRAINING = 'yes'` enables the new path in
  this fork's recipes. Set to `'no'` to fall back to the linear builder.

## Validation
No automated tests added (the repo's existing Perl `test/` harness isn't
wired into CMake and lacks a scaffold for this layer). Validated empirically:
- Each commit builds standalone.
- Trained CMU Arctic SLT end-to-end (CI through CD-4g) twice with multipron off and on, then force-aligned the 54 held-out utterances against both
  models with `sphinx3_align -outsent`.
  - Same model shape (means/variances/mixw/tmat all identical sizes).
  - Different model contents (`cmp` shows first diff in CI/CD means around
    byte 60).
  - 491 content tokens compared; 452 (92.1%) same variant, 39 (7.9%)
    different. 29 / 54 utterances had at least one disagreement,
    concentrated on high-frequency function words.
- Matches the reference implementation's numbers (93.6% / 6.4% on a
  slightly different cut).

## Net change

~1,050 lines new C, ~80 lines modifications, ~60 lines Perl/config.