### PR TITLE
Improve notes on multipron training

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ You do not need to install SphinxTrain to run it, simply run
 training directory.  Note that you do need to build and install
 PocketSphinx for evaluation to work properly, however.
 
+When packaging SphinxTrain inside another project, prefer a full
+`git clone` over `git clone --depth 1` if you expect to track
+`master` later.  A shallow working tree will sometimes refuse a plain
+`git pull --ff-only` and require an explicit `git fetch --unshallow`
+first.
+
 Multipron alignment (optional stage 21)
 ----------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,25 @@ text. It performs a **full** CI cycle again (including flat initialization)
 and **replaces** the CI model directory, roughly doubling CI time. Default
 is `no`.
 
+Multipron training (CFG_MULTIPRON_TRAINING)
+-------------------------------------------
+
+Independent of the stage-21 alignment, the Baum-Welch estimator (`bw`)
+can build per-utterance training HMMs with parallel paths per
+pronunciation variant and sum posteriors across variants. This is on by
+default (`$CFG_MULTIPRON_TRAINING = 'yes'` in `etc/sphinx_train.cfg`);
+set it to `no` for SphinxTrain-parity behaviour, in which `bw` silently
+picks pronunciation variant `[1]` for every multi-pron word.
+
+It composes with `$CFG_MULTIPRON` (stage 21): the alignment chooses the
+best single variant per utterance for `sphinx3_align` supervision while
+`bw` still distributes EM mass across variants during training. The
+default templates leave both on.
+
+`bw` memory and CPU per utterance scale with the average number of
+pronunciation variants per word; for single-variant lexicons the
+overhead is negligible.
+
 You can also install SphinxTrain system-wide if you so desire:
 
     sudo cmake --build build --target install

--- a/src/programs/bw/train_cmd_ln.c
+++ b/src/programs/bw/train_cmd_ln.c
@@ -555,7 +555,9 @@ If yo want to do parallel training for N machines. Run N trainers with \n\
 	  "no",
 	  "Build per-utterance training HMMs with parallel paths per "
 	  "pronunciation variant; forward-backward sums posteriors "
-	  "across variants. Default no for SphinxTrain parity." },
+	  "across variants. Default no for SphinxTrain parity. "
+	  "Set $CFG_MULTIPRON_TRAINING = 'yes' in sphinx_train.cfg "
+	  "to enable this for every bw stage." },
 	/* end */
 	
 	cepstral_to_feature_command_line_macro(),

--- a/templates/README
+++ b/templates/README
@@ -9,5 +9,19 @@ catalog numbers and required files.
 Some of the contents are inspired by Keith Vertanen's WSJ recipe
 (http://www.inference.phy.cam.ac.uk/kv227/sphinx/)
 
--- dhuggins@cs.cmu.edu, 2007-06-25
+Where to start
+--------------
 
+For a new project, the recommended reference is `librispeech/` (under
+`librispeech/etc/sphinx_train.cfg`).  It is the only template that is
+kept current with recent SphinxTrain options, and it documents the
+continuous (`.cont.`) and phonetically-tied (`.ptm.`) paths together
+with the multipron alignment (stage 21) and multipron Baum-Welch
+training knobs.
+
+The `rm/`, `tidigits/` and `wsj/` directories are older recipes kept
+for reference; they predate several current options (multipron, LDA,
+G2P, etc.) and are best treated as starting points rather than
+canonical configurations.
+
+-- dhuggins@cs.cmu.edu, 2007-06-25

--- a/templates/librispeech/etc/sphinx_train.cfg
+++ b/templates/librispeech/etc/sphinx_train.cfg
@@ -166,7 +166,14 @@ $CFG_FALIGN_CI_MGAU = 'no';
 $CFG_CI_MGAU = 'no';
 # (yes/no) Train context-dependent models
 $CFG_CD_TRAIN = 'yes';
-# Number of tied states (senones) to create in decision-tree clustering
+# Number of tied states (senones) to create in decision-tree clustering.
+# Rough sizing for continuous (.cont.) models with CFG_FINAL_NUM_DENSITIES
+# below:
+#   ~10 h training audio:    500 - 1000 senones,  4 -  8 densities
+#   ~100 h training audio:  2000 - 3000 senones,         8 densities
+#   ~1000 h training audio: 5000 - 8000 senones,         8 densities
+# Larger corpora generally benefit from more senones; densities above
+# ~16 give diminishing returns and slow training noticeably.
 $CFG_N_TIED_STATES = 5000;
 # How many parts to run Forward-Backward estimatinon in
 $CFG_NPART = 4;

--- a/templates/tidigits/etc/sphinx_train.template
+++ b/templates/tidigits/etc/sphinx_train.template
@@ -120,6 +120,12 @@ $CFG_CROSS_PHONE_TREES = 'no';
 # Use force-aligned transcripts (if available) as input to training
 $CFG_FORCEDALIGN = 'no';
 
+# Set to 'yes' to enable multi-pronunciation Baum-Welch (bw -multipron yes).
+# See the top-level README section "Multipron training" or
+# templates/librispeech/etc/sphinx_train.cfg for details. Default 'no'
+# matches historical SphinxTrain behaviour.
+# $CFG_MULTIPRON_TRAINING = 'no';
+
 # Use a specific set of models for force alignment.  If not defined,
 # context-independent models for the current experiment will be used.
 $CFG_FORCE_ALIGN_MODELDIR = "$CFG_MODEL_DIR/$CFG_EXPTNAME.falign_ci_$CFG_DIRLABEL";

--- a/templates/wsj/etc/sphinx_train.template
+++ b/templates/wsj/etc/sphinx_train.template
@@ -117,6 +117,12 @@ $CFG_CROSS_PHONE_TREES = 'no';
 # Use force-aligned transcripts (if available) as input to training
 $CFG_FORCEDALIGN = 'no';
 
+# Set to 'yes' to enable multi-pronunciation Baum-Welch (bw -multipron yes).
+# See the top-level README section "Multipron training" or
+# templates/librispeech/etc/sphinx_train.cfg for details. Default 'no'
+# matches historical SphinxTrain behaviour.
+# $CFG_MULTIPRON_TRAINING = 'no';
+
 # Use a specific set of models for force alignment.  If not defined,
 # context-independent models for the current experiment will be used.
 $CFG_FORCE_ALIGN_MODELDIR = "$CFG_MODEL_DIR/$CFG_EXPTNAME.falign_ci_$CFG_DIRLABEL";


### PR DESCRIPTION
# Docs and discoverability follow-up for CFG_MULTIPRON_TRAINING

Small, docs-focused follow-up to PR #58 (`kal-more-multi`). After that
PR landed, `CFG_MULTIPRON_TRAINING` was correctly threaded into every
`bw` stage, but it was only documented inside
`templates/librispeech/etc/sphinx_train.cfg`. A newcomer reading the
top-level README, `bw -help`, or any other template wouldn't discover
the knob exists.

This PR closes that documentation gap and adds a few unrelated small
ergonomic notes spotted in the same audit. No behavioural change in
any training path; the only C edit is one help-text string in `bw`.

## Commits

| # | Subject |
|---|---------|
| 1 | `docs: document CFG_MULTIPRON_TRAINING in README` |
| 2 | `bw: mention CFG_MULTIPRON_TRAINING in -multipron help text` |
| 3 | `templates: reference CFG_MULTIPRON_TRAINING in wsj/tidigits configs` |
| 4 | `templates: refresh README with current "where to start" pointer` |
| 5 | `templates: add tied-state and density sizing guide to librispeech cfg` |
| 6 | `docs: note --depth 1 caveat when packaging SphinxTrain` |

## What changes

- **`README.md`** – new section "Multipron training (CFG_MULTIPRON_TRAINING)"
  sibling to the existing stage-21 alignment section. Explains the
  Baum-Welch graph builder, the default, how it composes with
  `$CFG_MULTIPRON`, and the cost trade-off. Separately, a short note
  in the "Linux/Unix Installation" section about `git clone --depth 1`
  vs. `git fetch --unshallow` for downstream packagers.
- **`src/programs/bw/train_cmd_ln.c`** – one sentence appended to the
  `-multipron` argument doc so `bw -help` points users at the cfg knob
  that controls it across stages.
- **`templates/tidigits/etc/sphinx_train.template`** and
  **`templates/wsj/etc/sphinx_train.template`** – four-line commented
  `# $CFG_MULTIPRON_TRAINING = 'no';` reference with a pointer to the
  README and librispeech cfg. Inactive lines; no behavioural impact.
- **`templates/README`** – refreshed from the 2007 sign-off to add a
  "Where to start" pointer to `librispeech/` as the current reference
  and mark `rm/`, `tidigits/`, `wsj/` as older recipes. Original LDC
  blurb and dhuggins sign-off preserved.
- **`templates/librispeech/etc/sphinx_train.cfg`** – inline comment
  block next to `$CFG_N_TIED_STATES` with rule-of-thumb senone/density
  numbers for ~10 h / ~100 h / ~1000 h continuous-model training.
  The 5000 default is unchanged.
- No training code paths were touched. The only binary affected is
  `bw`, and only its help string.

## Verification

- `cmake -S . -B build && cmake --build build` clean (all binaries,
  including the modified `bw`).
- `perl -c` clean on the four edited Perl configs.
- `./build/bw -help | grep multipron` renders the new help text
  correctly.
- End-to-end training on CMU Arctic SLT (1043 train / 55 test, 3236-
  word multi-pron dict) with the locally-built tree:
  stages 000 → 50 all completed with `CFG_MULTIPRON_TRAINING = 'yes'`
  and `CFG_MULTIPRON = 'yes'`. Stage-20 and stage-50 bw logs both show
  `-multipron yes` and the multipron-aligned transcription being used
  at every density split (1g → 2g → 4g → 8g). Final CD-tied models
  written under `model_parameters/<expt>.cd_cont_200/`.
