### PR TITLE
Resolve procedural config to static json and use that for params

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Run tests
         run: |
           cmake --build sphinxtrain/build --target test
+          perl sphinxtrain/test/scripts/test_resolved_cfg.pl
       - name: Checkout PocketSphinx
         uses: actions/checkout@v4
         with:

--- a/python/cmusphinx/project_cfg.py
+++ b/python/cmusphinx/project_cfg.py
@@ -1,0 +1,35 @@
+"""Load sphinx_train.resolved.json produced by sphinxtrain run or resolve-config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class ConfigError(Exception):
+    pass
+
+
+def load_resolved(etc_dir: Path) -> dict:
+    path = etc_dir / "sphinx_train.resolved.json"
+    if not path.is_file():
+        raise ConfigError(
+            "missing etc/sphinx_train.resolved.json; run sphinxtrain run "
+            "(or resolve-config) from the project directory"
+        )
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def variable(doc: dict, name: str) -> str:
+    value = doc.get("variables", {}).get(name)
+    if value is None:
+        raise ConfigError(f"missing variables.{name} in sphinx_train.resolved.json")
+    return str(value)
+
+
+def derived(doc: dict, key: str) -> str:
+    value = doc.get("derived", {}).get(key)
+    if value is None:
+        raise ConfigError(f"missing derived.{key} in sphinx_train.resolved.json")
+    return str(value)

--- a/scripts/11.force_align/multipron_align.pl
+++ b/scripts/11.force_align/multipron_align.pl
@@ -27,6 +27,10 @@ if (!-f $py) {
     die "Missing $py\n";
 }
 
+my $pypath = catfile($ST::CFG_SPHINXTRAIN_DIR, 'python');
+$ENV{PYTHONPATH} = (defined($ENV{PYTHONPATH}) && $ENV{PYTHONPATH} ne '')
+    ? "$pypath:$ENV{PYTHONPATH}" : $pypath;
+
 # Prefer $PYTHON; else python3 on Unix (many images have no `python` symlink); else python.
 my $pyexe = $ENV{PYTHON};
 if (!defined($pyexe) || $pyexe eq '') {

--- a/scripts/11.force_align/multipron_align.py
+++ b/scripts/11.force_align/multipron_align.py
@@ -7,8 +7,8 @@ This mirrors scripts/11.force_align/slave_align.pl phases 3–4 (dictionary merg
 and scripts/11.force_align/force_align.pl (sphinx3_align invocation), without running the
 full SphinxTrain ``sphinxtrain run`` pipeline.
 
-Training layout comes from ``etc/sphinx_train.cfg`` (``CFG_BASE_DIR``, ``CFG_EXPTNAME``,
-and the usual align inputs). Outputs go under ``$CFG_BASE_DIR/multipron_align/``.
+Reads ``etc/sphinx_train.resolved.json`` (from ``sphinxtrain run`` or
+``resolve-config``). Outputs go under ``multipron_align/`` in the project base.
 Normally stage 21 runs this after CI when ``CFG_MULTIPRON`` is not ``no``. Set
 ``CFG_MULTIPRON`` to ``no`` to disable multipron entirely. Optional:
 ``CFG_SPHINX3_ALIGN_BINARY`` if ``sphinx3_align`` is not under ``CFG_BIN_DIR``. Beam width
@@ -35,54 +35,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-# One-line Perl assignments: $CFG_NAME = value;
-_ASSIGN = re.compile(
-    r"^\s*\$((?:CFG|ST)[A-Z0-9_]*)\s*=\s*(.*?)\s*;\s*(?:#.*)?$",
-    re.MULTILINE,
-)
+_python = Path(__file__).resolve().parents[2] / "python"
+if str(_python) not in sys.path:
+    sys.path.insert(0, str(_python))
 
-
-def _parse_sphinx_train_cfg(text: str) -> dict[str, str]:
-    raw: dict[str, str] = {}
-    for m in _ASSIGN.finditer(text):
-        name, val = m.group(1), m.group(2).strip()
-        if val.startswith(("'", '"')) and len(val) >= 2 and val[-1] == val[0]:
-            raw[name] = val[1:-1]
-        else:
-            raw[name] = val.rstrip(";").strip()
-    out = dict(raw)
-    for _ in range(24):
-        changed = False
-        for k, v in list(out.items()):
-            if "$" not in v:
-                continue
-            nv = v
-            for name, repl in out.items():
-                nv = nv.replace(f"${{{name}}}", repl)
-                nv = nv.replace(f"${name}", repl)
-            if nv != v:
-                out[k] = nv
-                changed = True
-        if not changed:
-            break
-    return out
-
-
-def _load_cfg(etc: Path) -> dict[str, str]:
-    cfg = etc / "sphinx_train.cfg"
-    if not cfg.is_file():
-        print(f"Missing {cfg}", file=sys.stderr)
-        sys.exit(1)
-    return _parse_sphinx_train_cfg(cfg.read_text(encoding="utf-8", errors="replace"))
-
-
-def _ci_dirlabel(hmm_type: str) -> str:
-    """Match sphinx_train.cfg: DIRLABEL follows HMM_TYPE, not a static parse."""
-    if hmm_type == ".semi.":
-        return "semi"
-    if hmm_type == ".ptm.":
-        return "ptm"
-    return "cont"
+from cmusphinx.project_cfg import ConfigError, load_resolved
 
 
 def _build_falign_dicts(
@@ -213,10 +170,16 @@ def main() -> int:
             continue
         print(f"Unexpected argument: {rest[i]}", file=sys.stderr)
         return 2
-    cfg = _load_cfg(etc)
+    try:
+        doc = load_resolved(etc)
+    except ConfigError as err:
+        print(err, file=sys.stderr)
+        return 1
+    cfg = doc["variables"]
+    derived = doc["derived"]
     base_dir = Path(cfg["CFG_BASE_DIR"])
     expt = cfg["CFG_EXPTNAME"]
-    out_root = out_dir if out_dir is not None else base_dir / "multipron_align"
+    out_root = out_dir if out_dir is not None else Path(derived["multipron_align_dir"])
 
     align_bin = (
         bin_override
@@ -234,15 +197,14 @@ def main() -> int:
         )
         return 1
 
-    dictionary = Path(cfg["CFG_DICTIONARY"])
+    dictionary = Path(derived["dictionary"])
     filler = Path(cfg["CFG_FILLERDICT"])
-    listoffiles = Path(cfg["CFG_LISTOFFILES"])
-    transcript = Path(cfg["CFG_TRANSCRIPTFILE"])
+    listoffiles = Path(derived["train_listoffiles"])
+    transcript = Path(derived["train_transcript"])
     ctlcount = "1000000"
     feat_dir = Path(cfg["CFG_FEATFILES_DIR"])
     feat_ext = "." + cfg["CFG_FEATFILE_EXTENSION"].lstrip(".")
-    hmm_type = cfg.get("CFG_HMM_TYPE", ".cont.")
-    hmm_dir = Path(cfg["CFG_MODEL_DIR"]) / f"{expt}.ci_{_ci_dirlabel(hmm_type)}"
+    hmm_dir = Path(derived["ci_hmm_dir"])
 
     if not hmm_dir.is_dir():
         print(f"Missing HMM directory {hmm_dir} (train CI models first).", file=sys.stderr)
@@ -269,7 +231,7 @@ def main() -> int:
     # sphinx3_align: -beam is a linear probability passed to logs3(); smaller p =>
     # wider Viterbi pruning (see s3_align.c). Default 1e-308 is effectively full width.
     beam = beam_override or cfg.get("CFG_FORCE_ALIGN_BEAM") or "1e-308"
-    statepdeffn = hmm_type
+    statepdeffn = cfg.get("CFG_HMM_TYPE", ".cont.")
     mwfloor = "1e-8"
     minvar = "1e-4"
 
@@ -316,6 +278,7 @@ def main() -> int:
         "-insert_sil",
         "1",
     ]
+    args = [str(a) for a in args]
 
     print("Doing multipron force alignment (sphinx3_align)...")
     if dry_run:

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SCRIPTDIRS
 decode
 lib
 prepare
+util
 )
 install(DIRECTORY ${SCRIPTDIRS} DESTINATION ${CMAKE_INSTALL_DATADIR}/sphinxtrain/scripts)
 install(PROGRAMS sphinxtrain TYPE BIN)

--- a/scripts/lib/SphinxTrain/Config.pm
+++ b/scripts/lib/SphinxTrain/Config.pm
@@ -40,6 +40,13 @@ use strict;
 package SphinxTrain::Config;
 use File::Spec;
 
+use constant CONFIG_PKG => "SphinxTrain::ProjectCfg";
+
+sub _do_cfg_in_package {
+    my ($cfg_file, $pkg) = @_;
+    eval "package $pkg; do \$cfg_file; die \$@ if \$@";
+}
+
 sub import {
     my ($self, %args) = @_;
 
@@ -61,8 +68,9 @@ sub import {
 	    die $@ if $@;
 	}
 	else {
-	    package ST;
-	    do $ST::CFG_FILE;
+	    _do_cfg_in_package($ST::CFG_FILE, CONFIG_PKG);
+	    require SphinxTrain::Resolved;
+	    SphinxTrain::Resolved::sync_runtime();
 	}
     }
 }
@@ -85,8 +93,8 @@ SphinxTrain::Config - Configuration management for Sphinx Training
 
 =head1 DESCRIPTION
 
-This module locates the configuration file and loads it into the ST::
-namespace.
+This module evaluates sphinx_train.cfg in a dedicated package, writes
+sphinx_train.resolved.json, and loads all variables into ST:: from that file.
 
 =head1 AUTHOR
 

--- a/scripts/lib/SphinxTrain/Resolved.pm
+++ b/scripts/lib/SphinxTrain/Resolved.pm
@@ -1,0 +1,213 @@
+# -*- cperl -*-
+## Evaluated CFG_* and derived paths; shared by Perl stages and Python tools.
+package SphinxTrain::Resolved;
+
+use strict;
+use File::Basename qw(dirname);
+use File::Spec;
+use POSIX qw(strftime);
+
+our $DOC;
+our $CONFIG_PKG = "SphinxTrain::ProjectCfg";
+
+sub resolved_path {
+    my $cfg = $ST::CFG_FILE;
+    return File::Spec->catfile(dirname($cfg), "sphinx_train.resolved.json");
+}
+
+sub _is_stale {
+    my ($resolved, $cfg) = @_;
+    return 1 unless -f $resolved;
+    # >= covers same-second cfg edits (1s mtime resolution on some platforms).
+    return (stat($cfg))[9] >= (stat($resolved))[9];
+}
+
+sub collect_variables {
+    my ($pkg) = @_;
+    $pkg = $CONFIG_PKG unless defined $pkg && $pkg ne "";
+    my %vars;
+    no strict "refs";
+    for my $name (keys %{"${pkg}::"}) {
+        next if $name =~ /::/;
+        next if $name =~ /^(?:ISA|BEGIN|INC|AUTOLOAD|VERSION)$/i;
+        my $val = ${"${pkg}::$name"};
+        next unless defined $val;
+        next if ref($val);
+        $vars{$name} = "$val";
+    }
+    return \%vars;
+}
+
+sub _dictionary_path {
+    if (defined($ST::CFG_FORCE_ALIGN_SPD) && $ST::CFG_FORCE_ALIGN_SPD eq "yes") {
+        return File::Spec->catfile($ST::CFG_BASE_DIR, "falignout",
+            "$ST::CFG_EXPTNAME.spdict");
+    }
+    if (defined($ST::CFG_G2P_MODEL) && $ST::CFG_G2P_MODEL eq "yes") {
+        return "$ST::CFG_DICTIONARY.full";
+    }
+    return $ST::CFG_DICTIONARY;
+}
+
+sub _multipron_transcript_path {
+    return File::Spec->catfile($ST::CFG_BASE_DIR, "multipron_align",
+        "$ST::CFG_EXPTNAME.multipron.transcription");
+}
+
+sub _should_use_multipron_transcript {
+    return 0 unless defined($ST::CFG_MULTIPRON);
+    return 0 if $ST::CFG_MULTIPRON eq "no";
+    return -f _multipron_transcript_path() ? 1 : 0;
+}
+
+sub compute_derived {
+    my %derived;
+    my $expt = $ST::CFG_EXPTNAME;
+    my $dirlabel = $ST::CFG_DIRLABEL;
+
+    $derived{ci_hmm_dir} = File::Spec->catfile(
+        $ST::CFG_MODEL_DIR, "${expt}.ci_${dirlabel}"
+    );
+
+    if (defined($ST::CFG_CD_TRAIN) && $ST::CFG_CD_TRAIN eq "yes") {
+        $derived{cd_hmm_dir} = File::Spec->catfile(
+            $ST::CFG_MODEL_DIR,
+            "${expt}.cd_${dirlabel}_$ST::CFG_N_TIED_STATES"
+        );
+    }
+
+    if (defined($ST::CFG_FORCE_ALIGN_MODELDIR)) {
+        $derived{falign_ci_hmm_dir} = $ST::CFG_FORCE_ALIGN_MODELDIR;
+    }
+
+    $derived{multipron_align_dir} = File::Spec->catdir(
+        $ST::CFG_BASE_DIR, "multipron_align"
+    );
+    $derived{multipron_transcript} = _multipron_transcript_path();
+
+    $derived{train_listoffiles} = $ST::CFG_LISTOFFILES;
+    $derived{train_transcript} = $ST::CFG_TRANSCRIPTFILE;
+
+    if (defined($ST::DEC_CFG_LISTOFFILES) && $ST::DEC_CFG_LISTOFFILES ne "") {
+        $derived{test_listoffiles} = $ST::DEC_CFG_LISTOFFILES;
+    }
+
+    $derived{dictionary} = _dictionary_path();
+    $derived{should_use_multipron_transcript} = _should_use_multipron_transcript();
+
+    return \%derived;
+}
+
+sub build_document {
+    my ($cfg_path) = @_;
+    $cfg_path = $ST::CFG_FILE unless defined $cfg_path && $cfg_path ne "";
+
+    my $source_mtime = (stat($cfg_path))[9];
+    die "Cannot stat config $cfg_path: $!\n" unless defined $source_mtime;
+
+    my $variables = collect_variables();
+    apply_variables($variables);
+
+    return {
+        meta => {
+            resolved_at    => strftime("%Y-%m-%dT%H:%M:%SZ", gmtime()),
+            source         => $cfg_path,
+            source_mtime   => $source_mtime + 0,
+            sphinxtrain_dir => $ST::CFG_SPHINXTRAIN_DIR,
+        },
+        variables => $variables,
+        derived   => compute_derived(),
+    };
+}
+
+sub _json_escape {
+    my ($s) = @_;
+    $s =~ s/\\/\\\\/g;
+    $s =~ s/"/\\"/g;
+    $s =~ s/\n/\\n/g;
+    $s =~ s/\r/\\r/g;
+    $s =~ s/\t/\\t/g;
+    return $s;
+}
+
+sub _json_value {
+    my ($v) = @_;
+    if (!defined $v) {
+        return "null";
+    }
+    if (ref($v) eq "HASH") {
+        my @pairs;
+        for my $k (sort keys %$v) {
+            push @pairs, _json_string($k) . ":" . _json_value($v->{$k});
+        }
+        return "{" . join(",", @pairs) . "}";
+    }
+    if ($v =~ /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/ && $v !~ /^0\d/) {
+        return $v;
+    }
+    if ($v eq "0" || $v eq "1") {
+        return $v;
+    }
+    return _json_string("$v");
+}
+
+sub _json_string {
+    my ($s) = @_;
+    return '"' . _json_escape($s) . '"';
+}
+
+sub to_json {
+    my ($doc) = @_;
+    return _json_value($doc) . "\n";
+}
+
+sub read_document {
+    my ($path) = @_;
+    open my $fh, "<", $path or die "Cannot read $path: $!\n";
+    local $/;
+    my $text = <$fh>;
+    close $fh;
+
+    if (eval { require JSON::PP; 1 }) {
+        return JSON::PP->new->decode($text);
+    }
+    die "JSON::PP is required to read $path\n";
+}
+
+sub write_file {
+    my ($path, $cfg_path) = @_;
+    my $doc = build_document($cfg_path);
+    open my $fh, ">", $path or die "Cannot write $path: $!\n";
+    print {$fh} to_json($doc);
+    close $fh or die "Cannot close $path: $!\n";
+    return $doc;
+}
+
+sub derived {
+    my ($key) = @_;
+    return undef unless $DOC && $DOC->{derived};
+    return $DOC->{derived}{$key};
+}
+
+sub apply_variables {
+    my ($vars) = @_;
+    return unless $vars && ref($vars) eq "HASH";
+    no strict "refs";
+    for my $name (keys %$vars) {
+        ${"ST::$name"} = $vars->{$name};
+    }
+}
+
+sub sync_runtime {
+    my $cfg = $ST::CFG_FILE;
+    my $resolved = resolved_path();
+    if (_is_stale($resolved, $cfg)) {
+        $DOC = write_file($resolved, $cfg);
+    } else {
+        $DOC = read_document($resolved);
+    }
+    apply_variables($DOC->{variables});
+    return $DOC;
+}
+
+1;

--- a/scripts/lib/SphinxTrain/Util.pm
+++ b/scripts/lib/SphinxTrain/Util.pm
@@ -608,29 +608,31 @@ Select and return the appropriate dictionary depending on predefined variables.
 =cut
 
 sub GetDict {
+    my $path = SphinxTrain::Resolved::derived("dictionary");
+    return $path if defined $path && $path ne "";
+
     if ($ST::CFG_FORCE_ALIGN_SPD eq "yes") {
 	return File::Spec->catfile($ST::CFG_BASE_DIR, "falignout",
 				   "${ST::CFG_EXPTNAME}.spdict");
     }
-    else {
-        my $dictfn;
-        if (defined $ST::CFG_G2P_MODEL && $ST::CFG_G2P_MODEL eq "yes") {
-            $dictfn = "$ST::CFG_DICTIONARY.full"
-        }
-        else {
-            $dictfn = "$ST::CFG_DICTIONARY"
-        }
-        return $dictfn;
+    if (defined $ST::CFG_G2P_MODEL && $ST::CFG_G2P_MODEL eq "yes") {
+        return "$ST::CFG_DICTIONARY.full";
     }
+    return $ST::CFG_DICTIONARY;
 }
 
 sub MultipronTranscriptFile {
+    my $path = SphinxTrain::Resolved::derived("multipron_transcript");
+    return $path if defined $path && $path ne "";
     return "$ST::CFG_BASE_DIR/multipron_align/${ST::CFG_EXPTNAME}.multipron.transcription";
 }
 
 # Multipron is on unless CFG_MULTIPRON is explicitly no. Use the multipron transcript
 # only after stage 21 has produced the file (after CI when multipron is enabled).
 sub ShouldUseMultipronTranscript {
+    if (defined $SphinxTrain::Resolved::DOC) {
+        return SphinxTrain::Resolved::derived("should_use_multipron_transcript");
+    }
     return 0 unless defined($ST::CFG_MULTIPRON);
     return 0 if $ST::CFG_MULTIPRON eq "no";
     return -f MultipronTranscriptFile();
@@ -650,11 +652,14 @@ sub GetLists {
 	$listoffiles   = "$ST::CFG_BASE_DIR/falignout/${ST::CFG_EXPTNAME}.alignedfiles";
 	$transcriptfile  = "$ST::CFG_BASE_DIR/falignout/${ST::CFG_EXPTNAME}.alignedtranscripts";
     } elsif (ShouldUseMultipronTranscript()) {
-	$listoffiles = $ST::CFG_LISTOFFILES;
+	$listoffiles = SphinxTrain::Resolved::derived("train_listoffiles")
+	    || $ST::CFG_LISTOFFILES;
 	$transcriptfile = MultipronTranscriptFile();
     } else {
-	$listoffiles = $ST::CFG_LISTOFFILES;
-	$transcriptfile = $ST::CFG_TRANSCRIPTFILE;
+	$listoffiles = SphinxTrain::Resolved::derived("train_listoffiles")
+	    || $ST::CFG_LISTOFFILES;
+	$transcriptfile = SphinxTrain::Resolved::derived("train_transcript")
+	    || $ST::CFG_TRANSCRIPTFILE;
     }
     return ($listoffiles, $transcriptfile);
 }

--- a/scripts/sphinxtrain
+++ b/scripts/sphinxtrain
@@ -3,12 +3,16 @@
 from __future__ import print_function
 
 import getopt
+import json
 import sys
 import os
 
 training_basedir = ""
 sphinxbinpath = ""
 sphinxpath = ""
+
+CFG_REL = os.path.join("etc", "sphinx_train.cfg")
+RESOLVED_REL = os.path.join("etc", "sphinx_train.resolved.json")
 
 
 def _perl_script_exit_code(status):
@@ -81,6 +85,42 @@ def setup(task):
     out_cfg.close()
 
 
+def _project_cfg_path(rel):
+    return os.path.join(training_basedir, rel)
+
+
+def _config_is_stale():
+    cfg_path = _project_cfg_path(CFG_REL)
+    resolved_path = _project_cfg_path(RESOLVED_REL)
+    if not os.path.isfile(resolved_path):
+        return True
+    return os.path.getmtime(cfg_path) >= os.path.getmtime(resolved_path)
+
+
+def ensure_resolved_config(force=False, verbose=False):
+    cfg_path = _project_cfg_path(CFG_REL)
+    resolved_path = _project_cfg_path(RESOLVED_REL)
+    if not os.path.isfile(cfg_path):
+        print("Missing " + cfg_path + " (run sphinxtrain setup first)")
+        sys.exit(1)
+    if not force and not _config_is_stale():
+        return
+    print("Resolving config from etc/sphinx_train.cfg ...")
+    dump_pl = os.path.join(sphinxpath, "scripts/util/dump_resolved_cfg.pl")
+    cmd = (
+        "perl '" + dump_pl + "' -cfg '" + cfg_path + "' -out '" + resolved_path + "'"
+    )
+    ret = os.system(cmd)
+    ec = _perl_script_exit_code(ret)
+    if ec != 0:
+        sys.exit(ec)
+    if verbose:
+        with open(resolved_path) as fh:
+            doc = json.load(fh)
+        for key in sorted(doc.get("derived", {})):
+            print("  " + key + ": " + str(doc["derived"][key]))
+
+
 steps = [
     "000.comp_feat/slave_feat.pl",
     "00.verify/verify_all.pl",
@@ -108,6 +148,7 @@ steps = [
 
 
 def run_stages(stages):
+    ensure_resolved_config()
     for stage in stages.split(","):
         for step in steps:
             name = step.split("/")[0].split(".")[-1]
@@ -120,6 +161,7 @@ def run_stages(stages):
 
 
 def run_from(stage):
+    ensure_resolved_config()
     found = False
     for step in steps:
         name = step.split("/")[0].split(".")[-1]
@@ -133,6 +175,7 @@ def run_from(stage):
 
 
 def run():
+    ensure_resolved_config()
     print("Running the training")
     for step in steps:
         ret = os.system("perl '" + sphinxpath + "/scripts/" + step + "'")
@@ -157,6 +200,7 @@ def usage():
     print("     -s <stage1,stage2,stage3> run - run selected stages")
     print("     -f <stage> run - run from selected stage")
     print("     run - run all training")
+    print("     resolve-config - refresh etc/sphinx_train.resolved.json")
     print("     list - list stages and exit")
 
 
@@ -204,6 +248,9 @@ def main():
             run_from(from_stage)
         else:
             run()
+    elif command == "resolve-config":
+        verbose = "-v" in sys.argv or "--verbose" in sys.argv
+        ensure_resolved_config(force=True, verbose=verbose)
     elif command == "list":
         print("\n".join(steps))
     else:

--- a/scripts/util/dump_resolved_cfg.pl
+++ b/scripts/util/dump_resolved_cfg.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+## Write evaluated sphinx_train.cfg to sphinx_train.resolved.json (stdout or -out).
+use strict;
+use File::Basename;
+use File::Spec::Functions qw(catdir updir);
+use Getopt::Long;
+
+my $cfg_file = "./etc/sphinx_train.cfg";
+my $out_file = "";
+GetOptions(
+    "cfg=s" => \$cfg_file,
+    "out=s" => \$out_file,
+) or exit 2;
+
+@ARGV = ("-cfg", $cfg_file);
+
+use lib catdir(dirname($0), updir(), "lib");
+use SphinxTrain::Config;
+use SphinxTrain::Resolved;
+
+if ($out_file ne "") {
+    $SphinxTrain::Resolved::DOC =
+        SphinxTrain::Resolved::write_file($out_file, $cfg_file);
+} else {
+    print SphinxTrain::Resolved::to_json($SphinxTrain::Resolved::DOC);
+}
+exit 0;

--- a/scripts/util/dump_resolved_cfg.pl
+++ b/scripts/util/dump_resolved_cfg.pl
@@ -5,6 +5,8 @@ use File::Basename;
 use File::Spec::Functions qw(catdir updir);
 use Getopt::Long;
 
+use lib catdir(dirname($0), updir(), "lib");
+
 my $cfg_file = "./etc/sphinx_train.cfg";
 my $out_file = "";
 GetOptions(
@@ -12,11 +14,9 @@ GetOptions(
     "out=s" => \$out_file,
 ) or exit 2;
 
-@ARGV = ("-cfg", $cfg_file);
-
-use lib catdir(dirname($0), updir(), "lib");
-use SphinxTrain::Config;
-use SphinxTrain::Resolved;
+require SphinxTrain::Config;
+SphinxTrain::Config->import(-cfg => $cfg_file);
+require SphinxTrain::Resolved;
 
 if ($out_file ne "") {
     $SphinxTrain::Resolved::DOC =

--- a/scripts/util/print_cfg_dirlabel.pl
+++ b/scripts/util/print_cfg_dirlabel.pl
@@ -1,0 +1,14 @@
+#!/usr/bin/env perl
+## Print $ST::CFG_DIRLABEL after Config + resolved sync (for tests).
+use strict;
+use File::Basename;
+use File::Spec::Functions qw(catdir updir);
+
+BEGIN {
+    @ARGV = ("-cfg", $ARGV[0]) if @ARGV == 1 && $ARGV[0] !~ /^-cfg$/;
+}
+
+use lib catdir(dirname($0), updir(), "lib");
+use SphinxTrain::Config;
+
+print "$SphinxTrain::Resolved::DOC->{variables}{CFG_DIRLABEL}\n";

--- a/test/scripts/test_resolved_cfg.pl
+++ b/test/scripts/test_resolved_cfg.pl
@@ -1,0 +1,140 @@
+#!/usr/bin/env perl
+## Resolved config: HMM type -> ci_hmm_dir; JSON shape; stale refresh via sphinxtrain.
+use strict;
+use File::Basename;
+use File::Path qw(make_path remove_tree);
+use File::Spec::Functions qw(catdir catfile);
+use Cwd qw(abs_path getcwd);
+
+my $root = abs_path(catdir(dirname($0), "..", ".."));
+my $dump = catfile($root, "scripts", "util", "dump_resolved_cfg.pl");
+my $src_cfg = catfile($root, "etc", "sphinx_train.cfg");
+my $work = catfile($root, "test", "work", "resolved_cfg_test");
+my $bindir = catfile($root, "build");
+
+remove_tree($work) if -d $work;
+make_path(catdir($work, "etc"));
+
+sub write_project_cfg {
+    open my $in, "<", $src_cfg or die "open $src_cfg: $!\n";
+    open my $out, ">", catfile($work, "etc", "sphinx_train.cfg")
+        or die "open project cfg: $!\n";
+    while (my $line = <$in>) {
+        $line =~ s/___DB_NAME___/testdb/g;
+        $line =~ s|___BASE_DIR___|$work|g;
+        $line =~ s|___SPHINXTRAIN_DIR___|$root|g;
+        $line =~ s|___SPHINXTRAIN_BIN_DIR___|$bindir|g;
+        print $out $line;
+    }
+    close $in;
+    close $out;
+}
+
+sub set_hmm_type {
+    my ($mode) = @_;
+    return if $mode eq "cont";
+    my $cfg = catfile($work, "etc", "sphinx_train.cfg");
+    open my $fh, "+<", $cfg or die "open $cfg: $!\n";
+    my @lines = <$fh>;
+    for (@lines) {
+        s/^\$CFG_HMM_TYPE = '\.cont\.';/#$&/;
+        if ($mode eq "semi") {
+            s/^#(\$CFG_HMM_TYPE  = '\.semi\.';)/$1/;
+        } else {
+            s/^#(\$CFG_HMM_TYPE  = '\.ptm\.';)/$1/;
+        }
+    }
+    seek $fh, 0, 0 or die "seek: $!\n";
+    print $fh @lines;
+    truncate $fh, tell($fh) or die "truncate: $!\n";
+    close $fh;
+}
+
+sub resolved_path {
+    return catfile($work, "etc", "sphinx_train.resolved.json");
+}
+
+sub run_dump {
+    my $cfg = catfile($work, "etc", "sphinx_train.cfg");
+    my $out = resolved_path();
+    system($^X, $dump, "-cfg", $cfg, "-out", $out) == 0
+        or die "dump_resolved_cfg.pl failed\n";
+    return $out;
+}
+
+sub cfg_dirlabel_via_config {
+    my ($cfg) = @_;
+    my $helper = catfile($root, "scripts", "util", "print_cfg_dirlabel.pl");
+    open my $fh, "-|", $^X, $helper, $cfg or die "fork config check: $!\n";
+    chomp(my $label = <$fh>);
+    close $fh;
+    wait;
+    return $label;
+}
+
+sub check_hmm_modes {
+    for my $mode (qw(cont semi ptm)) {
+        write_project_cfg();
+        set_hmm_type($mode);
+        my $cfg = catfile($work, "etc", "sphinx_train.cfg");
+        my $out = run_dump();
+        my $py = <<"PY";
+import json, sys
+doc = json.load(open(sys.argv[1]))
+label = sys.argv[2]
+assert doc["variables"]["CFG_DIRLABEL"] == label, doc["variables"]["CFG_DIRLABEL"]
+suffix = "ci_" + label
+assert doc["derived"]["ci_hmm_dir"].endswith("." + suffix), doc["derived"]["ci_hmm_dir"]
+assert "source_mtime" in doc["meta"]
+PY
+        system("python3", "-c", $py, $out, $mode) == 0
+            or die "JSON check failed for HMM $mode\n";
+        my $st_label = cfg_dirlabel_via_config($cfg);
+        die "resolved CFG_DIRLABEL=$st_label expected $mode after Config load\n"
+            if $st_label ne $mode;
+        print "ok $mode -> ci_$mode (json + resolved)\n";
+    }
+}
+
+sub check_stale_refresh {
+    write_project_cfg();
+    run_dump();
+    my $resolved = resolved_path();
+    my $cfg = catfile($work, "etc", "sphinx_train.cfg");
+    my $before = (stat($resolved))[9];
+    sleep 2;
+    utime(time, time + 2, $cfg);
+    my $driver = catfile($root, "scripts", "sphinxtrain");
+    my $cwd = getcwd();
+    chdir $work or die "chdir $work: $!\n";
+    system("python3", $driver, "resolve-config") == 0
+        or die "sphinxtrain resolve-config failed\n";
+    chdir $cwd or die "chdir back: $!\n";
+    my $after = (stat($resolved))[9];
+    die "resolved json mtime did not advance after cfg touch\n" if $after <= $before;
+    print "ok stale cfg triggers resolve-config\n";
+}
+
+sub check_project_cfg_load {
+    write_project_cfg();
+    run_dump();
+    my $out = resolved_path();
+    my $py = <<"PY";
+import sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[1])
+from cmusphinx.project_cfg import load_resolved
+doc = load_resolved(Path(sys.argv[2]))
+assert doc["derived"]["ci_hmm_dir"].endswith(".ci_cont")
+PY
+    system("python3", "-c", $py, catfile($root, "python"), catfile($work, "etc")) == 0
+        or die "project_cfg load failed\n";
+    print "ok project_cfg.load_resolved\n";
+}
+
+write_project_cfg();
+check_hmm_modes();
+check_stale_refresh();
+check_project_cfg_load();
+
+print "test_resolved_cfg passed\n";


### PR DESCRIPTION
## Flatten config and use consistently

There has been drift between the perl and python due to the procedural nature of `sphinx_train.cfg`. 

This PR introduces processing that turns that config into a namespace, then writes the resulting variables, both derived and global, into a `.resolved.json` file, and then downstream scripts in perl and/or python then use the common declaration.

It is expected that the `.cfg` file will be edited after `setup`, and the process is arranged to account for that.